### PR TITLE
Fix explore-feature skill path

### DIFF
--- a/.claude/skills/explore-feature/SKILL.md
+++ b/.claude/skills/explore-feature/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: explore-feature
 allowed-tools: Read, Grep, Glob, Bash(find:*), Bash(cargo:*), Bash(rg:*), Bash(wc:*), Bash(head:*), Bash(tail:*), Bash(cat:*), LSP, WebSearch, Agent
 argument-hint: <feature-idea-or-area>
 description: Explore and brainstorm a new Randlebrot/Margin's Grip feature — navigate the codebase, reference the game design docs, discuss design collaboratively, then break it down into parallelisable GitHub issues


### PR DESCRIPTION
## Summary
- Move from `.claude/commands/` to `.claude/skills/explore-feature/SKILL.md`
- Add missing `name` field to frontmatter

Previous path wasn't discoverable as a slash command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)