### PR TITLE
feat(cli): add clap CLI skeleton with subcommand routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,14 +96,48 @@ These rules derive from the game design and are non-negotiable constraints on th
 ## Build & Run
 
 ```bash
-cargo run                                        # editor mode (default)
-cargo run -- --play                              # play mode
+# ─── GUI (default) ───
+cargo run                                        # editor mode (default, same as `cargo run -- gui`)
+cargo run -- gui                                 # explicit editor launch
+cargo run -- gui my-layers-tag                   # editor, opening an existing layer artifact
+
+# ─── Headless generation ───
+cargo run -- generate layers 42 my-tag                        # generate layers for seed 42
+cargo run -- generate layers 42 my-tag --civ-seed 99          # separate civ seed
+cargo run -- generate layers 42 my-tag --backend cpu          # force CPU backend
+cargo run -- generate layers 42 my-tag --force                # overwrite existing tag
+cargo run -- generate level my-layers-tag 4,3 level-tag       # generate level from layers artifact
+cargo run -- generate level --seed 42 4,3 level-tag           # generate level from raw seed
+
+# ─── View artifacts ───
+cargo run -- view layers                         # list all layer artifacts
+cargo run -- view layers my-tag                  # inspect a specific layer artifact
+cargo run -- view levels                         # list all level artifacts
+cargo run -- view levels level-tag               # inspect a specific level artifact
+
+# ─── Launch playable level ───
+cargo run -- launch level-tag                    # play a previously generated level
+
+# ─── Tests & examples ───
 cargo test                                       # workspace tests
-cargo run -p rb_noise --example noise_preview    # noise debug visualization
-cargo run -p rb_tilemap --example tile_render    # tile rendering test
-cargo run -p rb_editor --example editor_shell    # editor UI test
 cargo run --release -p rb_noise --example save_debug_layers  # regenerate debug_layers/ PNGs
 ```
+
+## CLI Workflow
+
+The CLI follows a **generate → view → launch** pipeline:
+
+1. **Generate layers** — `randlebrot generate layers <seed> <tag>` runs the full TerrainGen + LifeGen pipeline headlessly (no window) and writes the result to a tagged artifact. Use `--civ-seed` to iterate on civilisation without regenerating terrain. Use `--backend cpu|gpu` to select the compute backend (default: gpu).
+
+2. **Generate level** — `randlebrot generate level <layers-tag|--seed N> <x,y> <tag>` generates a playable micro-level at the given chunk coordinate. The source is either a previously generated layers artifact (by tag) or a raw seed. Coordinate is a comma-separated `x,y` pair of i32 values.
+
+3. **View** — `randlebrot view layers` and `randlebrot view levels` list and inspect generated artifacts. Pass a tag to see detailed metadata for a specific artifact.
+
+4. **Launch** — `randlebrot launch <level-tag>` launches a playable level from a previously generated level artifact.
+
+5. **GUI** — `randlebrot gui [layers-tag]` (or just `randlebrot` with no args) launches the full Bevy editor. Optionally opens an existing layer artifact.
+
+Headless subcommands (`generate`, `view`) never initialize Bevy or create a window. Only `gui` and `launch` start the Bevy app.
 
 ### Debug Layer Workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,6 +1985,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2043,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -3251,6 +3347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4090,6 +4192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "orbclient"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4478,6 +4586,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_egui",
+ "clap",
  "image",
  "rayon",
  "rb_core",
@@ -5053,6 +5162,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5133,7 +5248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5461,6 +5576,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ noise = "0.9"
 serde = { version = "1", features = ["derive"] }
 ron = "0.8"
 bitflags = "2"
+clap = { version = "4", features = ["derive"] }
 
 # Internal crate dependencies
 rb_core = { path = "crates/rb_core" }
@@ -42,6 +43,7 @@ gpu = ["rb_noise/gpu"]
 [dependencies]
 bevy.workspace = true
 bevy_egui.workspace = true
+clap.workspace = true
 image.workspace = true
 rayon = "1.10"
 rb_core.workspace = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,14 +11,216 @@ use rb_player::Player;
 use rb_tilemap::{LevelChunk, LoadedChunks};
 use rb_world::{LifeGenData, PoliticalState, WorldDefinition};
 use bevy::window::PrimaryWindow;
+use clap::{Parser, Subcommand, ValueEnum, Args};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+
+// ─── CLI ────────────────────────────────────────────────────────────────────
+
+/// Randlebrot — procedural world engine for Margin's Grip
+#[derive(Parser, Debug)]
+#[command(name = "randlebrot", version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Launch the full Bevy editor (default when no subcommand given)
+    Gui {
+        /// Open an existing layer artifact by tag
+        layers_tag: Option<String>,
+    },
+
+    /// Generate world data (layers or levels)
+    Generate {
+        #[command(subcommand)]
+        target: GenerateTarget,
+    },
+
+    /// View and inspect generated artifacts
+    View {
+        #[command(subcommand)]
+        target: ViewTarget,
+    },
+
+    /// Launch a playable level from a previously generated level artifact
+    Launch {
+        /// Tag of the level artifact to launch
+        level_tag: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum GenerateTarget {
+    /// Generate terrain + civilisation layers for a world seed
+    Layers {
+        /// Terrain seed
+        seed: u32,
+
+        /// Tag name for the generated artifact
+        tag: String,
+
+        /// Civilisation seed (defaults to terrain seed if omitted)
+        #[arg(long)]
+        civ_seed: Option<u32>,
+
+        /// Compute backend
+        #[arg(long, value_enum, default_value_t = Backend::Gpu)]
+        backend: Backend,
+
+        /// Overwrite existing artifact with the same tag
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Generate a playable micro-level from a layers artifact or raw seed
+    Level {
+        #[command(flatten)]
+        source: LevelSource,
+
+        /// Chunk coordinate as x,y (comma-separated)
+        #[arg(value_parser = parse_coordinate)]
+        coord: (i32, i32),
+
+        /// Tag name for the generated level artifact
+        tag: String,
+
+        /// Compute backend
+        #[arg(long, value_enum, default_value_t = Backend::Gpu)]
+        backend: Backend,
+
+        /// Overwrite existing artifact with the same tag
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+/// Source for level generation — either a layers tag or a raw seed.
+/// Exactly one of `layers_tag` or `--seed` must be provided.
+#[derive(Args, Debug)]
+#[group(required = true, multiple = false)]
+struct LevelSource {
+    /// Use a previously generated layers artifact
+    #[arg(group = "source")]
+    layers_tag: Option<String>,
+
+    /// Generate from a raw terrain seed instead
+    #[arg(long, group = "source")]
+    seed: Option<u32>,
+}
+
+#[derive(Subcommand, Debug)]
+enum ViewTarget {
+    /// View layer artifacts
+    Layers {
+        /// Tag of a specific layers artifact to inspect (lists all if omitted)
+        tag: Option<String>,
+    },
+
+    /// View level artifacts
+    Levels {
+        /// Tag of a specific level artifact to inspect (lists all if omitted)
+        tag: Option<String>,
+    },
+}
+
+#[derive(ValueEnum, Clone, Debug)]
+enum Backend {
+    Gpu,
+    Cpu,
+}
+
+/// Parse a "x,y" coordinate string into an (i32, i32) pair.
+fn parse_coordinate(s: &str) -> Result<(i32, i32), String> {
+    let parts: Vec<&str> = s.splitn(2, ',').collect();
+    if parts.len() != 2 {
+        return Err(format!("expected x,y format, got '{s}'"));
+    }
+    let x = parts[0]
+        .trim()
+        .parse::<i32>()
+        .map_err(|e| format!("invalid x coordinate '{}': {e}", parts[0].trim()))?;
+    let y = parts[1]
+        .trim()
+        .parse::<i32>()
+        .map_err(|e| format!("invalid y coordinate '{}': {e}", parts[1].trim()))?;
+    Ok((x, y))
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        // No subcommand → default to GUI editor
+        None => launch_gui(None),
+
+        Some(Command::Gui { layers_tag }) => launch_gui(layers_tag),
+
+        Some(Command::Generate { target }) => match target {
+            GenerateTarget::Layers {
+                seed,
+                tag,
+                civ_seed,
+                backend,
+                force,
+            } => {
+                let civ = civ_seed.unwrap_or(seed);
+                println!(
+                    "generate layers: seed={seed}, tag={tag}, civ_seed={civ}, \
+                     backend={backend:?}, force={force} — not implemented yet"
+                );
+            }
+            GenerateTarget::Level {
+                source,
+                coord,
+                tag,
+                backend,
+                force,
+            } => {
+                let src = if let Some(ref t) = source.layers_tag {
+                    format!("layers_tag={t}")
+                } else {
+                    format!("seed={}", source.seed.unwrap())
+                };
+                println!(
+                    "generate level: {src}, coord=({},{}), tag={tag}, \
+                     backend={backend:?}, force={force} — not implemented yet",
+                    coord.0, coord.1,
+                );
+            }
+        },
+
+        Some(Command::View { target }) => match target {
+            ViewTarget::Layers { tag: None } => {
+                println!("view layers: listing all layer artifacts — not implemented yet");
+            }
+            ViewTarget::Layers { tag: Some(tag) } => {
+                println!("view layers: tag={tag} — not implemented yet");
+            }
+            ViewTarget::Levels { tag: None } => {
+                println!("view levels: listing all level artifacts — not implemented yet");
+            }
+            ViewTarget::Levels { tag: Some(tag) } => {
+                println!("view levels: tag={tag} — not implemented yet");
+            }
+        },
+
+        Some(Command::Launch { level_tag }) => {
+            println!("launch: level_tag={level_tag} — not implemented yet");
+        }
+    }
+}
+
+// ─── GUI Entrypoint ─────────────────────────────────────────────────────────
 
 const MAP_WIDTH: usize = 1024;
 const MAP_HEIGHT: usize = 512;
 const CHUNK_SIZE_I: usize = 64;
 
-fn main() {
+/// Launch the full Bevy editor GUI. This is the default entrypoint.
+fn launch_gui(_layers_tag: Option<String>) {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {


### PR DESCRIPTION
## Summary

Adds clap CLI parsing to randlebrot with the full subcommand tree. Closes #4.

## What's included

- clap derive API CLI struct with all subcommands
- `gui` (and no-args default) launches existing Bevy editor
- All other subcommands parse args and print "not implemented yet"
- No Bevy initialization for headless commands
- CLAUDE.md updated with CLI usage and workflow section

## CLI structure

```
randlebrot                                              # default -> gui
randlebrot gui [layers-tag]                             # full editor
randlebrot generate layers <seed> <tag> [--civ-seed N] [--backend gpu|cpu] [--force]
randlebrot generate level <layers-tag|--seed N> <x,y> <tag> [--backend gpu|cpu] [--force]
randlebrot view layers [tag]                            # list or inspect layer artifacts
randlebrot view levels [tag]                            # list or inspect level artifacts
randlebrot launch <level-tag>                           # playable level
```

## Acceptance Criteria from Issue

- [x] `clap` (derive API) added to workspace `Cargo.toml`
- [x] `randlebrot` with no args launches current Bevy editor (backward compatible)
- [x] `randlebrot gui` launches current Bevy editor
- [x] All other subcommands parse their arguments and print "not implemented yet"
- [x] `--help` works on every subcommand with clear descriptions
- [x] `--backend gpu|cpu` parsed on both generate subcommands (default: gpu)
- [x] `--civ-seed` optional on `generate layers`
- [x] `--force` flag on both generate subcommands
- [x] Coordinate arg parsed as `x,y`
- [x] No Bevy initialization for non-gui subcommands
- [x] `cargo test` passes

Generated with [Claude Code](https://claude.ai/claude-code)