### PR TITLE
feat(serde): add serialization to generation types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,6 +311,12 @@ DetailLevel   // Macro(0) / Meso(1) / Micro(2)
 AuthoredSite  // Capital { FullCityData } | Town { TownParams } | Village { seed } | Landmark { kind }
 ChunkParameters  // district_type, wealth, density, biome — derived from noise
 DistrictPalette  // noise ranges → TilesetId + SpawnTable mappings
+BiomeMap          // Serialize + Deserialize (skips: river_network — Arc<RiverNetwork>, rebuild from terrain)
+RiverNetwork      // Serialize + Deserialize (skips: spatial_index — rebuild via rebuild_spatial_index())
+ResourceMap       // Serialize + Deserialize
+TileType          // Serialize + Deserialize
+ResourceType      // Serialize + Deserialize
+LifeGenData       // Serialize + Deserialize (all nested types: Province, FactionData, SettlementSeed, RoadSegment)
 ```
 
 ### App Modes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1715,6 +1715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4533,6 +4542,7 @@ name = "rb_core"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "serde",
 ]
 
 [[package]]
@@ -4563,6 +4573,7 @@ name = "rb_noise"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bincode",
  "bytemuck",
  "image",
  "noise",
@@ -4571,6 +4582,7 @@ dependencies = [
  "rand_xorshift",
  "rayon",
  "rb_core",
+ "serde",
  "smallvec",
  "wgpu",
 ]
@@ -4612,6 +4624,7 @@ name = "rb_world"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "bincode",
  "image",
  "pathfinding",
  "rand 0.8.5",
@@ -4972,6 +4985,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -5133,7 +5149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ bevy_egui = "0.39"
 image = { version = "0.25", default-features = false, features = ["png"] }
 noise = "0.9"
 serde = { version = "1", features = ["derive"] }
+bincode = "1"
 ron = "0.8"
 bitflags = "2"
 

--- a/crates/rb_core/Cargo.toml
+++ b/crates/rb_core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bevy.workspace = true
+serde.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rb_core/src/biome.rs
+++ b/crates/rb_core/src/biome.rs
@@ -1,6 +1,8 @@
+use serde::{Deserialize, Serialize};
+
 /// Biome/tile types for world map generation.
 /// Uses multi-axis climate classification for realistic biome placement.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default, Serialize, Deserialize)]
 pub enum TileType {
     // Water types
     #[default]

--- a/crates/rb_core/src/resource_type.rs
+++ b/crates/rb_core/src/resource_type.rs
@@ -1,8 +1,10 @@
+use serde::{Deserialize, Serialize};
+
 use crate::TileType;
 
 /// Types of natural resources that can be found in the world.
 /// Each resource has terrain biases that affect where it appears.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ResourceType {
     // Metals (biased toward mountains/tectonic boundaries)
     Iron,

--- a/crates/rb_noise/Cargo.toml
+++ b/crates/rb_noise/Cargo.toml
@@ -12,8 +12,9 @@ rb_core.workspace = true
 noise.workspace = true
 image.workspace = true
 bevy.workspace = true
+serde.workspace = true
 rayon = "1.10"
-smallvec = "1.13"
+smallvec = { version = "1.13", features = ["serde"] }
 
 # GPU compute (optional)
 wgpu = { version = "27", optional = true }
@@ -24,6 +25,7 @@ rand_xorshift = { version = "0.3", optional = true }
 
 [dev-dependencies]
 bevy.workspace = true
+bincode.workspace = true
 
 [[example]]
 name = "noise_preview"

--- a/crates/rb_noise/src/biome_map.rs
+++ b/crates/rb_noise/src/biome_map.rs
@@ -1,5 +1,6 @@
 use rayon::prelude::*;
 use rb_core::{NoiseStrategy, TileType};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::biome_splines::BiomeSplines;
@@ -27,7 +28,7 @@ use crate::visualization::{
 pub const SEA_LEVEL: f64 = -0.01;
 
 /// Backend selection for noise generation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum NoiseBackend {
     /// CPU-based parallel noise generation using Rayon.
     Cpu,
@@ -55,6 +56,7 @@ impl NoiseBackend {
 ///
 /// This struct holds all the data needed to render different visualization
 /// layers (biome colors, temperature heatmap, etc.).
+#[derive(Serialize, Deserialize)]
 pub struct BiomeMap {
     pub width: usize,
     pub height: usize,
@@ -86,6 +88,8 @@ pub struct BiomeMap {
     pub resource_map: Option<ResourceMap>,
 
     /// Global river network (only set on the macro-level 1024×512 map).
+    /// Skipped during serialization — rebuild from terrain data after deserialization.
+    #[serde(skip)]
     pub river_network: Option<Arc<RiverNetwork>>,
 
     /// Drainage area from erosion sim (macro-level, sampled at other levels).
@@ -1986,5 +1990,42 @@ mod tests {
         assert!(violations.is_empty(),
             "Found {} non-White biomes in polar cap (light < 0.05). First 5: {:?}",
             violations.len(), &violations[..violations.len().min(5)]);
+    }
+
+    #[test]
+    fn biome_map_bincode_roundtrip() {
+        let map = BiomeMap::generate(42, 64, 32);
+        let encoded = bincode::serialize(&map).expect("serialize BiomeMap");
+        let decoded: BiomeMap = bincode::deserialize(&encoded).expect("deserialize BiomeMap");
+
+        assert_eq!(map.width, decoded.width);
+        assert_eq!(map.height, decoded.height);
+        assert_eq!(map.continentalness, decoded.continentalness);
+        assert_eq!(map.tectonic, decoded.tectonic);
+        assert_eq!(map.tectonic_plate_ids, decoded.tectonic_plate_ids);
+        assert_eq!(map.humidity, decoded.humidity);
+        assert_eq!(map.rock_hardness, decoded.rock_hardness);
+        assert_eq!(map.light_level, decoded.light_level);
+        assert_eq!(map.peaks_valleys, decoded.peaks_valleys);
+        assert_eq!(map.volcanism, decoded.volcanism);
+        assert_eq!(map.heightmap, decoded.heightmap);
+        assert_eq!(map.temperature, decoded.temperature);
+        assert_eq!(map.erosion, decoded.erosion);
+        assert_eq!(map.rivers, decoded.rivers);
+        assert_eq!(map.aridity, decoded.aridity);
+        assert_eq!(map.precipitation_type, decoded.precipitation_type);
+        assert_eq!(map.water_table, decoded.water_table);
+        assert_eq!(map.wind_speed, decoded.wind_speed);
+        assert_eq!(map.resource_richness, decoded.resource_richness);
+        assert_eq!(map.snowpack, decoded.snowpack);
+        assert_eq!(map.biomes, decoded.biomes);
+        assert_eq!(map.vegetation_density, decoded.vegetation_density);
+        assert_eq!(map.soil_type, decoded.soil_type);
+        assert_eq!(map.drainage_area, decoded.drainage_area);
+        assert_eq!(map.sediment, decoded.sediment);
+        assert_eq!(map.world_width, decoded.world_width);
+        assert_eq!(map.world_height, decoded.world_height);
+        // river_network is skipped (Arc<RiverNetwork>), so it deserializes as None
+        assert!(decoded.river_network.is_none());
     }
 }

--- a/crates/rb_noise/src/resource_map.rs
+++ b/crates/rb_noise/src/resource_map.rs
@@ -1,9 +1,11 @@
 use rb_core::ResourceType;
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use std::collections::HashMap;
 
 /// Sparse resource map - only stores cells with resources above threshold.
 /// This avoids storing 12 dense vectors for resource types (would be ~50MB at 1024x512).
+#[derive(Serialize, Deserialize)]
 pub struct ResourceMap {
     pub width: usize,
     pub height: usize,

--- a/crates/rb_noise/src/rivers.rs
+++ b/crates/rb_noise/src/rivers.rs
@@ -14,6 +14,7 @@
 //! Chunks call `RiverNetwork::query_chunk()` which returns segments filtered
 //! by a drainage threshold that varies with LOD level.
 
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, BinaryHeap, VecDeque};
 use std::cmp::Ordering;
 
@@ -50,7 +51,7 @@ pub(crate) const NO_FLOW: u8 = 255;
 // ─── River Character ─────────────────────────────────────────────────────────
 
 /// Climate-aware river classification sampled at each segment's midpoint.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RiverCharacter {
     /// Light > 0.7, low humidity — carved channel, no surface water.
     DryWadi,
@@ -96,7 +97,7 @@ impl RiverCharacter {
 
 /// A stretch of river between two confluences (or between a source and a
 /// confluence, or between a confluence and the ocean mouth).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RiverSegment {
     /// Unique segment ID.
     pub id: usize,
@@ -119,7 +120,7 @@ pub struct RiverSegment {
 // ─── Lake ────────────────────────────────────────────────────────────────────
 
 /// A natural lake (depression that wasn't fully filled).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Lake {
     /// Cells comprising the lake surface (world coordinates).
     pub cells: Vec<(f64, f64)>,
@@ -135,7 +136,7 @@ pub struct Lake {
 
 /// A river constraint returned by chunk queries.
 /// Contains everything a chunk needs to render/carve a river segment.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RiverConstraint {
     /// Path points within the queried bounds (world coords).
     pub path: Vec<(f64, f64)>,
@@ -159,7 +160,7 @@ pub struct RiverConstraint {
 
 /// Simple chunk coordinate for the spatial index.
 /// Uses the macro pixel grid (1 unit = 1 world unit for macro maps).
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 struct RiverChunkCoord {
     x: i32,
     y: i32,
@@ -168,10 +169,13 @@ struct RiverChunkCoord {
 // ─── River Network ───────────────────────────────────────────────────────────
 
 /// Top-level immutable river network. Computed once during world generation.
+#[derive(Serialize, Deserialize)]
 pub struct RiverNetwork {
     /// All segments in the network.
     pub segments: Vec<RiverSegment>,
     /// Spatial index: which segment IDs pass through each chunk cell.
+    /// Skipped during serialization — rebuilt from segments via `rebuild_spatial_index()`.
+    #[serde(skip)]
     spatial_index: HashMap<RiverChunkCoord, Vec<usize>>,
     /// Natural lakes (depressions that weren't filled).
     pub lakes: Vec<Lake>,
@@ -301,6 +305,12 @@ impl RiverNetwork {
             spatial_index,
             lakes,
         }
+    }
+
+    /// Rebuild the spatial index from segments.
+    /// Call this after deserialization to restore query capability.
+    pub fn rebuild_spatial_index(&mut self) {
+        self.spatial_index = build_spatial_index(&self.segments);
     }
 
     /// Query river segments intersecting a rectangular bounds,
@@ -1850,6 +1860,7 @@ pub fn carve_river_channels(
 
 /// Legacy river generator for backward compatibility.
 /// Wraps the new RiverNetwork system but provides the old Vec<f64> interface.
+#[derive(Serialize, Deserialize)]
 pub struct RiverGenerator {
     pub sea_level: f64,
     pub min_accumulation: u32,
@@ -2599,5 +2610,72 @@ mod tests {
         assert!(wet_count >= dry_count,
             "Wet climate should have >= river pixels ({}) than dry ({})",
             wet_count, dry_count);
+    }
+
+    #[test]
+    fn river_network_bincode_roundtrip() {
+        // Build a small river network manually for the test
+        let segments = vec![
+            RiverSegment {
+                id: 0,
+                path: vec![(10.0, 5.0), (11.0, 6.0), (12.0, 7.0)],
+                drainage_area: 500,
+                downstream: None,
+                upstream: vec![1],
+                character: RiverCharacter::Permanent,
+                meander_offsets: vec![0.0, 0.1, -0.1],
+                strahler_order: 2,
+            },
+            RiverSegment {
+                id: 1,
+                path: vec![(8.0, 3.0), (9.0, 4.0), (10.0, 5.0)],
+                drainage_area: 200,
+                downstream: Some(0),
+                upstream: vec![],
+                character: RiverCharacter::SeasonalFlow,
+                meander_offsets: vec![0.0, 0.0, 0.0],
+                strahler_order: 1,
+            },
+        ];
+        let lakes = vec![
+            Lake {
+                cells: vec![(15.0, 15.0), (15.0, 16.0)],
+                drainage_area: 300,
+                outlet: Some(0),
+                frozen: false,
+            },
+        ];
+        let spatial_index = build_spatial_index(&segments);
+        let network = RiverNetwork { segments, spatial_index, lakes };
+
+        let encoded = bincode::serialize(&network).expect("serialize RiverNetwork");
+        let mut decoded: RiverNetwork = bincode::deserialize(&encoded).expect("deserialize RiverNetwork");
+
+        // Verify segments round-trip
+        assert_eq!(network.segments.len(), decoded.segments.len());
+        for (orig, deser) in network.segments.iter().zip(decoded.segments.iter()) {
+            assert_eq!(orig.id, deser.id);
+            assert_eq!(orig.path, deser.path);
+            assert_eq!(orig.drainage_area, deser.drainage_area);
+            assert_eq!(orig.downstream, deser.downstream);
+            assert_eq!(orig.upstream, deser.upstream);
+            assert_eq!(orig.character, deser.character);
+            assert_eq!(orig.meander_offsets, deser.meander_offsets);
+            assert_eq!(orig.strahler_order, deser.strahler_order);
+        }
+
+        // Verify lakes round-trip
+        assert_eq!(network.lakes.len(), decoded.lakes.len());
+        assert_eq!(network.lakes[0].cells, decoded.lakes[0].cells);
+        assert_eq!(network.lakes[0].drainage_area, decoded.lakes[0].drainage_area);
+        assert_eq!(network.lakes[0].outlet, decoded.lakes[0].outlet);
+        assert_eq!(network.lakes[0].frozen, decoded.lakes[0].frozen);
+
+        // spatial_index is skipped, so it should be empty after deserialization
+        assert!(decoded.spatial_index.is_empty());
+
+        // Rebuild and verify it works
+        decoded.rebuild_spatial_index();
+        assert!(!decoded.spatial_index.is_empty());
     }
 }

--- a/crates/rb_world/Cargo.toml
+++ b/crates/rb_world/Cargo.toml
@@ -15,6 +15,9 @@ rand_chacha = "0.3"
 image.workspace = true
 rayon = "1.10"
 
+[dev-dependencies]
+bincode.workspace = true
+
 [[example]]
 name = "save_lifegen_layers"
 path = "examples/save_lifegen_layers.rs"

--- a/crates/rb_world/src/lifegen_data.rs
+++ b/crates/rb_world/src/lifegen_data.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use rb_core::TileType;
 use rb_noise::BiomeMap;
+use serde::{Deserialize, Serialize};
 
 use crate::definition::{CityTier, WorldDefinition};
 use crate::roads::{terrain_movement_cost, RoadType};
@@ -8,7 +9,7 @@ use crate::roads::{terrain_movement_cost, RoadType};
 /// Complete output of civilisation generation.
 /// All grid layers are at 8192x4096 meso pixel resolution.
 /// Immutable after world gen (will support mutation via political tick later).
-#[derive(Resource, Debug)]
+#[derive(Resource, Debug, Serialize, Deserialize)]
 pub struct LifeGenData {
     pub width: usize,
     pub height: usize,
@@ -36,7 +37,7 @@ pub struct LifeGenData {
     pub trade_edges: Vec<(u32, u32, f32)>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Province {
     pub id: u16,
     pub site: (f64, f64),
@@ -50,14 +51,14 @@ pub struct Province {
     pub political_state: PoliticalState,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PoliticalState {
     Claimed { faction_id: u32 },
     Unclaimed,
     Uninhabited,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FactionData {
     pub id: u32,
     pub name: String,
@@ -65,7 +66,7 @@ pub struct FactionData {
     pub capital_province: u16,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SettlementSeed {
     pub id: u32,
     pub position: (f64, f64),
@@ -74,7 +75,7 @@ pub struct SettlementSeed {
     pub tier: SettlementTier,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SizeClass {
     Metropolis,
     City,
@@ -84,7 +85,7 @@ pub enum SizeClass {
     Ruins,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SettlementTier {
     Capital,
     Major,
@@ -94,7 +95,7 @@ pub enum SettlementTier {
     Ruins,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoadSegment {
     pub from: (f64, f64),
     pub to: (f64, f64),
@@ -1184,5 +1185,107 @@ fn bresenham_core(x0: i32, y0: i32, x1: i32, y1: i32, plot: &mut dyn FnMut(i32, 
             err += dx;
             cy += sy;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifegen_data_bincode_roundtrip() {
+        let mut data = LifeGenData::empty(16, 8);
+
+        // Add some provinces
+        data.provinces.push(Province {
+            id: 1,
+            site: (100.0, 200.0),
+            biome: TileType::Plains,
+            habitability: 0.8,
+            area_px: 500,
+            is_coastal: true,
+            is_river_junction: false,
+            elevation_mean: 0.15,
+            terrain_cost: 1.2,
+            political_state: PoliticalState::Claimed { faction_id: 1 },
+        });
+        data.provinces.push(Province {
+            id: 2,
+            site: (300.0, 400.0),
+            biome: TileType::Mountain,
+            habitability: 0.3,
+            area_px: 800,
+            is_coastal: false,
+            is_river_junction: true,
+            elevation_mean: 0.6,
+            terrain_cost: 3.5,
+            political_state: PoliticalState::Unclaimed,
+        });
+
+        // Add a faction
+        data.factions.push(FactionData {
+            id: 1,
+            name: "Test Faction".to_string(),
+            colour: [255, 0, 0, 255],
+            capital_province: 1,
+        });
+        data.faction_ids = vec![0; 16 * 8];
+
+        // Add a settlement
+        data.settlement_seeds.push(SettlementSeed {
+            id: 1,
+            position: (100.0, 200.0),
+            province_id: 1,
+            size_class: SizeClass::City,
+            tier: SettlementTier::Capital,
+        });
+
+        // Add a road segment
+        data.road_segments.push(RoadSegment {
+            from: (100.0, 200.0),
+            to: (300.0, 400.0),
+            cost: 5.0,
+            road_type_id: 0,
+        });
+
+        // Add a trade edge
+        data.trade_edges.push((1, 2, 10.5));
+
+        // Set some habitability values
+        data.habitability[0] = 0.9;
+        data.habitability[5] = 0.4;
+
+        let encoded = bincode::serialize(&data).expect("serialize LifeGenData");
+        let decoded: LifeGenData = bincode::deserialize(&encoded).expect("deserialize LifeGenData");
+
+        assert_eq!(data.width, decoded.width);
+        assert_eq!(data.height, decoded.height);
+        assert_eq!(data.habitability, decoded.habitability);
+        assert_eq!(data.navigation_cost, decoded.navigation_cost);
+        assert_eq!(data.resource_desirability, decoded.resource_desirability);
+        assert_eq!(data.province_ids, decoded.province_ids);
+        assert_eq!(data.faction_ids, decoded.faction_ids);
+        assert_eq!(data.trade_edges, decoded.trade_edges);
+
+        // Check provinces
+        assert_eq!(data.provinces.len(), decoded.provinces.len());
+        assert_eq!(data.provinces[0].id, decoded.provinces[0].id);
+        assert_eq!(data.provinces[0].biome, decoded.provinces[0].biome);
+        assert_eq!(data.provinces[0].is_coastal, decoded.provinces[0].is_coastal);
+
+        // Check factions
+        assert_eq!(data.factions.len(), decoded.factions.len());
+        assert_eq!(data.factions[0].name, decoded.factions[0].name);
+        assert_eq!(data.factions[0].colour, decoded.factions[0].colour);
+
+        // Check settlements
+        assert_eq!(data.settlement_seeds.len(), decoded.settlement_seeds.len());
+        assert_eq!(data.settlement_seeds[0].size_class, decoded.settlement_seeds[0].size_class);
+        assert_eq!(data.settlement_seeds[0].tier, decoded.settlement_seeds[0].tier);
+
+        // Check road segments
+        assert_eq!(data.road_segments.len(), decoded.road_segments.len());
+        assert_eq!(data.road_segments[0].from, decoded.road_segments[0].from);
+        assert_eq!(data.road_segments[0].road_type_id, decoded.road_segments[0].road_type_id);
     }
 }


### PR DESCRIPTION
## Summary

Adds serde Serialize/Deserialize derives to all generation output types. Closes #5.

## What's included

- Serde derives on BiomeMap, RiverNetwork, TileType, ResourceType, ResourceMap, and all nested types in rb_noise
- Serde derives on LifeGenData, Province, FactionData, SettlementSeed, SizeClass, SettlementTier, PoliticalState, RoadSegment in rb_world
- Non-serializable fields (Arc<RiverNetwork>, spatial index cache) marked with #[serde(skip)]
- `rebuild_spatial_index()` method on RiverNetwork for post-deserialization rebuild
- Bincode round-trip tests for BiomeMap, RiverNetwork, and LifeGenData
- CLAUDE.md Key Types section updated with serialization notes
- `serde` and `bincode` added to workspace Cargo.toml; smallvec serde feature enabled

## Acceptance Criteria from Issue

- [x] `serde` and `bincode` added to workspace `Cargo.toml`
- [x] All types reachable from `BiomeMap` implement `Serialize + Deserialize`
- [x] All types reachable from `RiverNetwork` implement `Serialize + Deserialize`
- [x] All types reachable from `LifeGenData` implement `Serialize + Deserialize`
- [x] `TileType` implements `Serialize + Deserialize`
- [x] Non-serializable fields marked `#[serde(skip)]`
- [x] Round-trip tests for BiomeMap, RiverNetwork, LifeGenData
- [x] `cargo test` passes across workspace
- [x] No changes to generation logic

## Skipped Fields

| Type | Field | Reason | Rebuild Strategy |
|------|-------|--------|------------------|
| `BiomeMap` | `river_network: Option<Arc<RiverNetwork>>` | `Arc` not serializable | Regenerate from terrain data, or serialize RiverNetwork separately |
| `RiverNetwork` | `spatial_index: HashMap<RiverChunkCoord, Vec<usize>>` | Derived cache | Call `rebuild_spatial_index()` after deserialization |

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy -- -D warnings` clean (only pre-existing unknown_lints warning)
- [x] `cargo test --workspace` all 239 tests pass
- [x] New round-trip tests verify bincode serialize/deserialize for BiomeMap, RiverNetwork, LifeGenData

🤖 Generated with [Claude Code](https://claude.ai/claude-code)