### PR TITLE
feat(artifacts): create rb_artifacts crate -- artifact store and manifests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,8 @@ randlebrot/
 │   │   ├── generator_ui.rs    # World Generator mode UI (seed, params, save/load)
 │   │   └── launcher_ui.rs     # Level Launcher UI (phase-aware side panel, LauncherPhase state machine)
 │   ├── rb_player/        # Player controller, camera, 2D top-down interaction
-│   └── rb_persistence/   # Delta storage, save/load (RON format)
+│   ├── rb_persistence/   # Delta storage, save/load (RON format)
+│   └── rb_artifacts/     # Artifact storage: ~/.randlebrot/ layer/level persistence, manifests
 ├── assets/
 │   ├── tilesets/         # Tileset sprite sheets
 │   ├── authored/         # Hand-placed data: plates, landmarks, key NPCs (RON files)
@@ -183,6 +184,7 @@ rb_entity_spawn  → rb_core, rb_world, rb_tilemap
 rb_editor        → rb_core, rb_noise, rb_world, rb_tilemap, bevy_egui
 rb_player        → rb_core, rb_tilemap
 rb_persistence   → rb_core, rb_world, rb_tilemap
+rb_artifacts     → rb_core, rb_noise, rb_world
 ```
 
 ## Architecture
@@ -425,6 +427,34 @@ RegenerationRequest // Signal to regenerate world map from updated params
 CursorWorldPos      // Cursor position in world coordinates for chunk highlighting
 PlayableLevel       // Active playable level state (origin, seed, etc.)
 ```
+
+### Artifact Storage
+
+The `rb_artifacts` crate manages `~/.randlebrot/` for persistent layer and level artifacts.
+
+```
+~/.randlebrot/
+├── layers/
+│   └── <tag>/
+│       ├── manifest.ron           # LayerManifest (seed, civ_seed, timestamp, dims, backend, layer list)
+│       ├── macro_biome.bin        # bincode: BiomeMap (1024×512 macro)
+│       ├── river_network.bin      # bincode: RiverNetwork (separate from BiomeMap — Arc is serde(skip))
+│       ├── lifegen.bin            # bincode: LifeGenData
+│       └── images/                # layer PNGs (4096×2048, same as save_debug_layers output)
+│           ├── biome.png
+│           ├── heightmap.png
+│           └── ... (~20 layers)
+└── levels/
+    └── <tag>/
+        ├── manifest.ron           # LevelManifest (parent layers tag, seed, civ_seed, micro coord, timestamp)
+        └── micro_biome.bin        # bincode: micro-level BiomeMap
+```
+
+**Estimated sizes:** Layer artifacts are ~200-400 MB (dominated by bincode BiomeMap at 1024×512 with ~20 f64 layers + LifeGenData at 8192×4096). Layer PNGs add ~20-40 MB. Level artifacts are much smaller (~50-100 MB for a single micro BiomeMap).
+
+**Tags:** Alphanumeric + hyphens + underscores only. Used as directory names.
+
+**Manifests:** Pretty-printed RON for human readability. `LayerManifest` records seed, civ_seed, world dimensions, backend used, and list of available image filenames. `LevelManifest` records the parent layers tag, seed, civ_seed, micro coordinate, and timestamp.
 
 ### Map Navigation & Controls
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,6 +3190,30 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -4598,6 +4636,7 @@ dependencies = [
  "clap",
  "image",
  "rayon",
+ "rb_artifacts",
  "rb_core",
  "rb_editor",
  "rb_entity_spawn",
@@ -4644,6 +4683,21 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rb_artifacts"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "chrono",
+ "image",
+ "rb_core",
+ "rb_noise",
+ "rb_world",
+ "ron 0.8.1",
+ "serde",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/rb_editor",
     "crates/rb_player",
     "crates/rb_persistence",
+    "crates/rb_artifacts",
 ]
 
 [workspace.dependencies]
@@ -31,6 +32,7 @@ rb_entity_spawn = { path = "crates/rb_entity_spawn" }
 rb_editor = { path = "crates/rb_editor" }
 rb_player = { path = "crates/rb_player" }
 rb_persistence = { path = "crates/rb_persistence" }
+rb_artifacts = { path = "crates/rb_artifacts" }
 
 [package]
 name = "randlebrot"
@@ -55,6 +57,7 @@ rb_entity_spawn.workspace = true
 rb_editor.workspace = true
 rb_player.workspace = true
 rb_persistence.workspace = true
+rb_artifacts.workspace = true
 
 [workspace.lints.clippy]
 # TODO: fix these and remove the allows

--- a/crates/rb_artifacts/Cargo.toml
+++ b/crates/rb_artifacts/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rb_artifacts"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rb_core.workspace = true
+rb_noise.workspace = true
+rb_world.workspace = true
+serde.workspace = true
+bincode.workspace = true
+ron.workspace = true
+image.workspace = true
+chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/rb_artifacts/src/error.rs
+++ b/crates/rb_artifacts/src/error.rs
@@ -1,0 +1,105 @@
+//! Error types for artifact storage operations.
+
+use std::fmt;
+use std::path::PathBuf;
+
+/// Errors that can occur during artifact storage operations.
+#[derive(Debug)]
+pub enum ArtifactError {
+    /// Failed to determine the home directory.
+    NoHomeDirectory,
+    /// The provided tag contains invalid characters.
+    InvalidTag {
+        tag: String,
+        reason: &'static str,
+    },
+    /// An artifact with this tag already exists.
+    AlreadyExists {
+        kind: String,
+        tag: String,
+    },
+    /// The requested artifact was not found.
+    NotFound {
+        kind: String,
+        tag: String,
+    },
+    /// A file within the artifact could not be found.
+    FileNotFound {
+        path: PathBuf,
+    },
+    /// Filesystem I/O error with context.
+    Io {
+        context: String,
+        source: std::io::Error,
+    },
+    /// Bincode serialization/deserialization error.
+    Bincode {
+        context: String,
+        source: bincode::Error,
+    },
+    /// RON serialization error.
+    RonSerialize {
+        context: String,
+        source: ron::Error,
+    },
+    /// RON deserialization error.
+    RonDeserialize {
+        context: String,
+        source: ron::error::SpannedError,
+    },
+    /// Image save error.
+    Image {
+        context: String,
+        source: image::ImageError,
+    },
+}
+
+impl fmt::Display for ArtifactError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoHomeDirectory => {
+                write!(f, "could not determine home directory")
+            }
+            Self::InvalidTag { tag, reason } => {
+                write!(f, "invalid artifact tag '{tag}': {reason}")
+            }
+            Self::AlreadyExists { kind, tag } => {
+                write!(f, "{kind} artifact '{tag}' already exists")
+            }
+            Self::NotFound { kind, tag } => {
+                write!(f, "{kind} artifact '{tag}' not found")
+            }
+            Self::FileNotFound { path } => {
+                write!(f, "file not found: {}", path.display())
+            }
+            Self::Io { context, source } => {
+                write!(f, "{context}: {source}")
+            }
+            Self::Bincode { context, source } => {
+                write!(f, "{context}: {source}")
+            }
+            Self::RonSerialize { context, source } => {
+                write!(f, "{context}: {source}")
+            }
+            Self::RonDeserialize { context, source } => {
+                write!(f, "{context}: {source}")
+            }
+            Self::Image { context, source } => {
+                write!(f, "{context}: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ArtifactError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::Bincode { source, .. } => Some(source.as_ref()),
+            Self::RonSerialize { source, .. } => Some(source),
+            Self::RonDeserialize { source, .. } => Some(source),
+            Self::Image { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}

--- a/crates/rb_artifacts/src/lib.rs
+++ b/crates/rb_artifacts/src/lib.rs
@@ -1,0 +1,33 @@
+//! Artifact storage for Randlebrot.
+//!
+//! Manages the `~/.randlebrot/` directory for persisting layer and level artifacts.
+//! Layer artifacts contain the full TerrainGen + LifeGen output (BiomeMap, RiverNetwork,
+//! LifeGenData, and debug PNG images). Level artifacts contain micro-level BiomeMap data.
+//!
+//! ## On-Disk Layout
+//!
+//! ```text
+//! ~/.randlebrot/
+//! +-- layers/
+//! |   +-- <tag>/
+//! |       +-- manifest.ron           # LayerManifest
+//! |       +-- macro_biome.bin        # bincode: BiomeMap
+//! |       +-- river_network.bin      # bincode: RiverNetwork
+//! |       +-- lifegen.bin            # bincode: LifeGenData
+//! |       +-- images/                # layer PNGs
+//! |           +-- biome.png
+//! |           +-- heightmap.png
+//! |           +-- ...
+//! +-- levels/
+//!     +-- <tag>/
+//!         +-- manifest.ron           # LevelManifest
+//!         +-- micro_biome.bin        # bincode: micro-level BiomeMap
+//! ```
+
+mod error;
+mod manifest;
+mod store;
+
+pub use error::ArtifactError;
+pub use manifest::{LayerManifest, LevelManifest};
+pub use store::{ArtifactKind, ArtifactStore};

--- a/crates/rb_artifacts/src/manifest.rs
+++ b/crates/rb_artifacts/src/manifest.rs
@@ -1,0 +1,40 @@
+//! Manifest types for layer and level artifacts.
+//!
+//! Manifests are stored as pretty-printed RON files for human readability.
+//! They contain metadata about the artifact without the heavy binary data.
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata for a layer artifact (TerrainGen + LifeGen output).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LayerManifest {
+    /// Terrain generation seed.
+    pub seed: u32,
+    /// Civilisation generation seed.
+    pub civ_seed: u32,
+    /// ISO 8601 timestamp of creation.
+    pub created: String,
+    /// World width in world units.
+    pub world_width: u32,
+    /// World height in world units.
+    pub world_height: u32,
+    /// Noise backend used for generation ("cpu" or "gpu").
+    pub backend: String,
+    /// List of available layer image filenames (e.g. ["biome.png", "heightmap.png"]).
+    pub layer_images: Vec<String>,
+}
+
+/// Metadata for a level artifact (micro-level BiomeMap).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LevelManifest {
+    /// Tag of the parent layers artifact this level was generated from, if any.
+    pub parent_layers_tag: Option<String>,
+    /// Terrain generation seed.
+    pub seed: u32,
+    /// Civilisation generation seed.
+    pub civ_seed: u32,
+    /// Micro-level chunk coordinate (x, y).
+    pub micro_coord: (i32, i32),
+    /// ISO 8601 timestamp of creation.
+    pub created: String,
+}

--- a/crates/rb_artifacts/src/store.rs
+++ b/crates/rb_artifacts/src/store.rs
@@ -1,0 +1,772 @@
+//! Artifact store managing `~/.randlebrot/` for layer and level persistence.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use image::{ImageBuffer, Rgba};
+use rb_noise::{BiomeMap, RiverNetwork};
+use rb_world::lifegen_data::LifeGenData;
+
+use crate::error::ArtifactError;
+use crate::manifest::{LayerManifest, LevelManifest};
+
+// ─── File Names ─────────────────────────────────────────────────────────────
+
+const MANIFEST_FILE: &str = "manifest.ron";
+const MACRO_BIOME_FILE: &str = "macro_biome.bin";
+const RIVER_NETWORK_FILE: &str = "river_network.bin";
+const LIFEGEN_FILE: &str = "lifegen.bin";
+const MICRO_BIOME_FILE: &str = "micro_biome.bin";
+const IMAGES_DIR: &str = "images";
+
+// ─── Artifact Kind ──────────────────────────────────────────────────────────
+
+/// The kind of artifact (layers or levels).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactKind {
+    /// Full layer artifact: macro BiomeMap + RiverNetwork + LifeGenData + images.
+    Layers,
+    /// Level artifact: micro BiomeMap for a specific chunk coordinate.
+    Levels,
+}
+
+impl ArtifactKind {
+    /// Directory name under `~/.randlebrot/`.
+    fn dir_name(&self) -> &'static str {
+        match self {
+            Self::Layers => "layers",
+            Self::Levels => "levels",
+        }
+    }
+
+    /// Human-readable name for error messages.
+    fn display_name(&self) -> &'static str {
+        match self {
+            Self::Layers => "layers",
+            Self::Levels => "levels",
+        }
+    }
+}
+
+// ─── ArtifactStore ──────────────────────────────────────────────────────────
+
+/// Manages the `~/.randlebrot/` artifact directory.
+///
+/// Provides save/load operations for layer artifacts (TerrainGen + LifeGen output)
+/// and level artifacts (micro-level BiomeMap).
+pub struct ArtifactStore {
+    base_path: PathBuf,
+}
+
+impl ArtifactStore {
+    /// Create a new artifact store at `~/.randlebrot/`.
+    ///
+    /// Creates the base directory and `layers/` and `levels/` subdirectories
+    /// if they do not exist.
+    pub fn new() -> Result<Self, ArtifactError> {
+        let home = home_dir()?;
+        let base_path = home.join(".randlebrot");
+        Self::with_base_path(base_path)
+    }
+
+    /// Create an artifact store at a custom base path.
+    ///
+    /// Useful for testing with temporary directories.
+    pub fn with_base_path(base_path: PathBuf) -> Result<Self, ArtifactError> {
+        for kind in &[ArtifactKind::Layers, ArtifactKind::Levels] {
+            let dir = base_path.join(kind.dir_name());
+            fs::create_dir_all(&dir).map_err(|e| ArtifactError::Io {
+                context: format!("creating directory {}", dir.display()),
+                source: e,
+            })?;
+        }
+        Ok(Self { base_path })
+    }
+
+    /// Base path of the artifact store (`~/.randlebrot/`).
+    pub fn base_path(&self) -> &Path {
+        &self.base_path
+    }
+
+    // ─── Layer Operations ───────────────────────────────────────────────
+
+    /// Save a complete layer artifact.
+    ///
+    /// Writes the macro BiomeMap, RiverNetwork, and LifeGenData as bincode files,
+    /// any provided layer images as PNGs, and a RON manifest.
+    ///
+    /// # Arguments
+    /// * `tag` - Unique identifier for this artifact (alphanumeric + hyphens + underscores)
+    /// * `biome_map` - The macro-level BiomeMap (1024x512)
+    /// * `river_network` - The global river network (serialized separately from BiomeMap)
+    /// * `lifegen` - The civilisation generation output
+    /// * `images` - Map of layer name to RGBA image data (width, height, rgba_bytes)
+    /// * `manifest` - Metadata about this generation run
+    pub fn save_layers(
+        &self,
+        tag: &str,
+        biome_map: &BiomeMap,
+        river_network: &RiverNetwork,
+        lifegen: &LifeGenData,
+        images: &HashMap<String, (u32, u32, Vec<u8>)>,
+        manifest: &LayerManifest,
+    ) -> Result<(), ArtifactError> {
+        validate_tag(tag)?;
+        let dir = self.artifact_dir(ArtifactKind::Layers, tag);
+        let images_dir = dir.join(IMAGES_DIR);
+        fs::create_dir_all(&images_dir).map_err(|e| ArtifactError::Io {
+            context: format!("creating layers directory {}", dir.display()),
+            source: e,
+        })?;
+
+        // Write bincode files
+        write_bincode(&dir.join(MACRO_BIOME_FILE), biome_map, "macro BiomeMap")?;
+        write_bincode(
+            &dir.join(RIVER_NETWORK_FILE),
+            river_network,
+            "RiverNetwork",
+        )?;
+        write_bincode(&dir.join(LIFEGEN_FILE), lifegen, "LifeGenData")?;
+
+        // Write layer images
+        for (name, (width, height, rgba_data)) in images {
+            let path = images_dir.join(name);
+            let img: ImageBuffer<Rgba<u8>, _> =
+                ImageBuffer::from_raw(*width, *height, rgba_data.clone()).ok_or_else(|| {
+                    ArtifactError::Io {
+                        context: format!("image buffer size mismatch for {name}"),
+                        source: std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "RGBA data length does not match width*height*4",
+                        ),
+                    }
+                })?;
+            img.save(&path).map_err(|e| ArtifactError::Image {
+                context: format!("saving layer image {}", path.display()),
+                source: e,
+            })?;
+        }
+
+        // Write manifest (pretty-printed RON)
+        write_ron_manifest(&dir.join(MANIFEST_FILE), manifest, "layer manifest")?;
+
+        Ok(())
+    }
+
+    /// Load the binary data for a layer artifact.
+    ///
+    /// Returns the BiomeMap, RiverNetwork, and LifeGenData.
+    /// Note: `BiomeMap.river_network` will be `None` after deserialization
+    /// (it is `#[serde(skip)]` because of `Arc`). The caller should reconnect
+    /// the returned `RiverNetwork` to the `BiomeMap` as needed.
+    pub fn load_layers_data(
+        &self,
+        tag: &str,
+    ) -> Result<(BiomeMap, RiverNetwork, LifeGenData), ArtifactError> {
+        validate_tag(tag)?;
+        let dir = self.artifact_dir(ArtifactKind::Layers, tag);
+        if !dir.exists() {
+            return Err(ArtifactError::NotFound {
+                kind: ArtifactKind::Layers.display_name().to_string(),
+                tag: tag.to_string(),
+            });
+        }
+
+        let biome_map = read_bincode(&dir.join(MACRO_BIOME_FILE), "macro BiomeMap")?;
+        let river_network = read_bincode(&dir.join(RIVER_NETWORK_FILE), "RiverNetwork")?;
+        let lifegen = read_bincode(&dir.join(LIFEGEN_FILE), "LifeGenData")?;
+
+        Ok((biome_map, river_network, lifegen))
+    }
+
+    /// Load only the manifest for a layer artifact (cheap, no binary data).
+    pub fn load_layer_manifest(&self, tag: &str) -> Result<LayerManifest, ArtifactError> {
+        validate_tag(tag)?;
+        let dir = self.artifact_dir(ArtifactKind::Layers, tag);
+        if !dir.exists() {
+            return Err(ArtifactError::NotFound {
+                kind: ArtifactKind::Layers.display_name().to_string(),
+                tag: tag.to_string(),
+            });
+        }
+        read_ron_manifest(&dir.join(MANIFEST_FILE), "layer manifest")
+    }
+
+    /// Resolve the path to a specific layer image PNG.
+    pub fn layer_image_path(&self, tag: &str, layer_name: &str) -> PathBuf {
+        self.artifact_dir(ArtifactKind::Layers, tag)
+            .join(IMAGES_DIR)
+            .join(layer_name)
+    }
+
+    // ─── Level Operations ───────────────────────────────────────────────
+
+    /// Save a level artifact (micro-level BiomeMap + manifest).
+    pub fn save_level(
+        &self,
+        tag: &str,
+        micro_biome: &BiomeMap,
+        manifest: &LevelManifest,
+    ) -> Result<(), ArtifactError> {
+        validate_tag(tag)?;
+        let dir = self.artifact_dir(ArtifactKind::Levels, tag);
+        fs::create_dir_all(&dir).map_err(|e| ArtifactError::Io {
+            context: format!("creating levels directory {}", dir.display()),
+            source: e,
+        })?;
+
+        write_bincode(&dir.join(MICRO_BIOME_FILE), micro_biome, "micro BiomeMap")?;
+        write_ron_manifest(&dir.join(MANIFEST_FILE), manifest, "level manifest")?;
+
+        Ok(())
+    }
+
+    /// Load a level artifact (micro BiomeMap + manifest).
+    pub fn load_level(&self, tag: &str) -> Result<(BiomeMap, LevelManifest), ArtifactError> {
+        validate_tag(tag)?;
+        let dir = self.artifact_dir(ArtifactKind::Levels, tag);
+        if !dir.exists() {
+            return Err(ArtifactError::NotFound {
+                kind: ArtifactKind::Levels.display_name().to_string(),
+                tag: tag.to_string(),
+            });
+        }
+
+        let micro_biome = read_bincode(&dir.join(MICRO_BIOME_FILE), "micro BiomeMap")?;
+        let manifest = read_ron_manifest(&dir.join(MANIFEST_FILE), "level manifest")?;
+
+        Ok((micro_biome, manifest))
+    }
+
+    // ─── Listing ────────────────────────────────────────────────────────
+
+    /// List all layer artifacts with their manifests.
+    ///
+    /// Returns `(tag, manifest)` pairs for all valid layer artifacts.
+    /// Artifacts with unreadable manifests are silently skipped.
+    pub fn list_layers(&self) -> Result<Vec<(String, LayerManifest)>, ArtifactError> {
+        self.list_artifacts(ArtifactKind::Layers)
+    }
+
+    /// List all level artifacts with their manifests.
+    ///
+    /// Returns `(tag, manifest)` pairs for all valid level artifacts.
+    /// Artifacts with unreadable manifests are silently skipped.
+    pub fn list_levels(&self) -> Result<Vec<(String, LevelManifest)>, ArtifactError> {
+        self.list_artifacts(ArtifactKind::Levels)
+    }
+
+    // ─── Deletion & Existence ───────────────────────────────────────────
+
+    /// Delete an artifact directory.
+    pub fn delete(&self, kind: ArtifactKind, tag: &str) -> Result<(), ArtifactError> {
+        validate_tag(tag)?;
+        let dir = self.artifact_dir(kind, tag);
+        if !dir.exists() {
+            return Err(ArtifactError::NotFound {
+                kind: kind.display_name().to_string(),
+                tag: tag.to_string(),
+            });
+        }
+        fs::remove_dir_all(&dir).map_err(|e| ArtifactError::Io {
+            context: format!("deleting {} artifact '{}'", kind.display_name(), tag),
+            source: e,
+        })
+    }
+
+    /// Check whether an artifact with the given kind and tag exists.
+    pub fn exists(&self, kind: ArtifactKind, tag: &str) -> bool {
+        if validate_tag(tag).is_err() {
+            return false;
+        }
+        self.artifact_dir(kind, tag).exists()
+    }
+
+    // ─── Internal Helpers ───────────────────────────────────────────────
+
+    fn artifact_dir(&self, kind: ArtifactKind, tag: &str) -> PathBuf {
+        self.base_path.join(kind.dir_name()).join(tag)
+    }
+
+    fn list_artifacts<M>(&self, kind: ArtifactKind) -> Result<Vec<(String, M)>, ArtifactError>
+    where
+        M: serde::de::DeserializeOwned,
+    {
+        let parent = self.base_path.join(kind.dir_name());
+        let entries = fs::read_dir(&parent).map_err(|e| ArtifactError::Io {
+            context: format!("reading {} directory", kind.display_name()),
+            source: e,
+        })?;
+
+        let mut results = Vec::new();
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let tag = match path.file_name().and_then(|n| n.to_str()) {
+                Some(name) => name.to_string(),
+                None => continue,
+            };
+            let manifest_path = path.join(MANIFEST_FILE);
+            if !manifest_path.exists() {
+                continue;
+            }
+            match read_ron_manifest::<M>(&manifest_path, "manifest") {
+                Ok(manifest) => results.push((tag, manifest)),
+                Err(_) => continue,
+            }
+        }
+
+        results.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(results)
+    }
+}
+
+// ─── Tag Validation ─────────────────────────────────────────────────────────
+
+/// Validate an artifact tag.
+///
+/// Tags must be non-empty and contain only alphanumeric characters, hyphens, and underscores.
+fn validate_tag(tag: &str) -> Result<(), ArtifactError> {
+    if tag.is_empty() {
+        return Err(ArtifactError::InvalidTag {
+            tag: tag.to_string(),
+            reason: "tag must not be empty",
+        });
+    }
+    if !tag
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(ArtifactError::InvalidTag {
+            tag: tag.to_string(),
+            reason: "tag must contain only alphanumeric characters, hyphens, and underscores",
+        });
+    }
+    Ok(())
+}
+
+// ─── Serialization Helpers ──────────────────────────────────────────────────
+
+fn write_bincode<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    context: &str,
+) -> Result<(), ArtifactError> {
+    let data = bincode::serialize(value).map_err(|e| ArtifactError::Bincode {
+        context: format!("serializing {context}"),
+        source: e,
+    })?;
+    fs::write(path, &data).map_err(|e| ArtifactError::Io {
+        context: format!("writing {context} to {}", path.display()),
+        source: e,
+    })
+}
+
+fn read_bincode<T: serde::de::DeserializeOwned>(
+    path: &Path,
+    context: &str,
+) -> Result<T, ArtifactError> {
+    if !path.exists() {
+        return Err(ArtifactError::FileNotFound {
+            path: path.to_path_buf(),
+        });
+    }
+    let data = fs::read(path).map_err(|e| ArtifactError::Io {
+        context: format!("reading {context} from {}", path.display()),
+        source: e,
+    })?;
+    bincode::deserialize(&data).map_err(|e| ArtifactError::Bincode {
+        context: format!("deserializing {context} from {}", path.display()),
+        source: e,
+    })
+}
+
+fn write_ron_manifest<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    context: &str,
+) -> Result<(), ArtifactError> {
+    let pretty = ron::ser::PrettyConfig::default();
+    let text =
+        ron::ser::to_string_pretty(value, pretty).map_err(|e| ArtifactError::RonSerialize {
+            context: format!("serializing {context}"),
+            source: e,
+        })?;
+    fs::write(path, text.as_bytes()).map_err(|e| ArtifactError::Io {
+        context: format!("writing {context} to {}", path.display()),
+        source: e,
+    })
+}
+
+fn read_ron_manifest<T: serde::de::DeserializeOwned>(
+    path: &Path,
+    context: &str,
+) -> Result<T, ArtifactError> {
+    if !path.exists() {
+        return Err(ArtifactError::FileNotFound {
+            path: path.to_path_buf(),
+        });
+    }
+    let text = fs::read_to_string(path).map_err(|e| ArtifactError::Io {
+        context: format!("reading {context} from {}", path.display()),
+        source: e,
+    })?;
+    ron::de::from_str(&text).map_err(|e| ArtifactError::RonDeserialize {
+        context: format!("deserializing {context} from {}", path.display()),
+        source: e,
+    })
+}
+
+// ─── Home Directory ─────────────────────────────────────────────────────────
+
+fn home_dir() -> Result<PathBuf, ArtifactError> {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .map_err(|_| ArtifactError::NoHomeDirectory)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{LayerManifest, LevelManifest};
+    use rb_core::TileType;
+    use rb_noise::RiverNetwork;
+
+    /// Create a minimal BiomeMap for testing.
+    fn make_test_biome_map() -> BiomeMap {
+        let w = 4;
+        let h = 4;
+        let n = w * h;
+        BiomeMap {
+            width: w,
+            height: h,
+            continentalness: vec![0.0; n],
+            tectonic: vec![0.0; n],
+            tectonic_plate_ids: vec![0.0; n],
+            humidity: vec![0.5; n],
+            rock_hardness: vec![0.5; n],
+            light_level: vec![0.5; n],
+            peaks_valleys: vec![0.0; n],
+            volcanism: vec![0.0; n],
+            heightmap: vec![0.1; n],
+            temperature: vec![20.0; n],
+            erosion: vec![0.0; n],
+            rivers: vec![0.0; n],
+            aridity: vec![0.3; n],
+            precipitation_type: vec![0.0; n],
+            water_table: vec![0.2; n],
+            wind_speed: vec![0.1; n],
+            resource_richness: vec![0.0; n],
+            snowpack: vec![0.0; n],
+            biomes: vec![TileType::Plains; n],
+            vegetation_density: vec![0.5; n],
+            soil_type: vec![0.5; n],
+            resource_map: None,
+            river_network: None,
+            drainage_area: vec![0; n],
+            sediment: vec![0.0; n],
+            world_width: 4.0,
+            world_height: 4.0,
+        }
+    }
+
+    /// Create a minimal RiverNetwork for testing via serde round-trip.
+    fn make_test_river_network() -> RiverNetwork {
+        // RiverNetwork has a private spatial_index field with #[serde(skip)],
+        // so we construct an empty one via serde deserialization.
+        let ron_str = "(segments: [], lakes: [])";
+        ron::de::from_str(ron_str).expect("failed to deserialize empty RiverNetwork")
+    }
+
+    /// Create a minimal LifeGenData for testing.
+    fn make_test_lifegen_data() -> LifeGenData {
+        let w = 8;
+        let h = 4;
+        let n = w * h;
+        LifeGenData {
+            width: w,
+            height: h,
+            habitability: vec![0.5; n],
+            navigation_cost: vec![1.0; n],
+            resource_desirability: vec![0.3; n],
+            province_ids: vec![0u16; n],
+            provinces: vec![],
+            faction_ids: vec![0u32; n],
+            factions: vec![],
+            settlement_seeds: vec![],
+            road_segments: vec![],
+            trade_edges: vec![],
+        }
+    }
+
+    fn make_layer_manifest() -> LayerManifest {
+        LayerManifest {
+            seed: 42,
+            civ_seed: 99,
+            created: "2026-01-15T12:00:00Z".to_string(),
+            world_width: 1024,
+            world_height: 512,
+            backend: "cpu".to_string(),
+            layer_images: vec!["biome.png".to_string()],
+        }
+    }
+
+    fn make_level_manifest() -> LevelManifest {
+        LevelManifest {
+            parent_layers_tag: Some("test-layers".to_string()),
+            seed: 42,
+            civ_seed: 99,
+            micro_coord: (4, 3),
+            created: "2026-01-15T12:30:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn tag_validation_accepts_valid_tags() {
+        assert!(validate_tag("my-layers-42").is_ok());
+        assert!(validate_tag("test_tag").is_ok());
+        assert!(validate_tag("CamelCase123").is_ok());
+        assert!(validate_tag("a").is_ok());
+    }
+
+    #[test]
+    fn tag_validation_rejects_empty() {
+        assert!(validate_tag("").is_err());
+    }
+
+    #[test]
+    fn tag_validation_rejects_spaces() {
+        assert!(validate_tag("has space").is_err());
+    }
+
+    #[test]
+    fn tag_validation_rejects_slashes() {
+        assert!(validate_tag("path/traversal").is_err());
+        assert!(validate_tag("../escape").is_err());
+    }
+
+    #[test]
+    fn tag_validation_rejects_dots() {
+        assert!(validate_tag("has.dot").is_err());
+    }
+
+    #[test]
+    fn round_trip_layers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        let biome_map = make_test_biome_map();
+        let river_network = make_test_river_network();
+        let lifegen = make_test_lifegen_data();
+        let manifest = make_layer_manifest();
+
+        // Create a small test image (2x2 RGBA)
+        let mut images = HashMap::new();
+        let rgba_data = vec![255u8; 2 * 2 * 4];
+        images.insert("biome.png".to_string(), (2, 2, rgba_data));
+
+        store
+            .save_layers("test-layers", &biome_map, &river_network, &lifegen, &images, &manifest)
+            .unwrap();
+
+        // Verify manifest round-trip
+        let loaded_manifest = store.load_layer_manifest("test-layers").unwrap();
+        assert_eq!(loaded_manifest, manifest);
+
+        // Verify binary data round-trip
+        let (loaded_bm, loaded_rn, loaded_lg) = store.load_layers_data("test-layers").unwrap();
+        assert_eq!(loaded_bm.width, biome_map.width);
+        assert_eq!(loaded_bm.height, biome_map.height);
+        assert_eq!(loaded_bm.continentalness, biome_map.continentalness);
+        assert_eq!(loaded_bm.temperature, biome_map.temperature);
+        assert_eq!(loaded_bm.biomes, biome_map.biomes);
+        assert_eq!(loaded_rn.segments.len(), river_network.segments.len());
+        assert_eq!(loaded_lg.width, lifegen.width);
+        assert_eq!(loaded_lg.height, lifegen.height);
+        assert_eq!(loaded_lg.habitability, lifegen.habitability);
+
+        // BiomeMap.river_network should be None (serde skip)
+        assert!(loaded_bm.river_network.is_none());
+
+        // Image file should exist
+        let img_path = store.layer_image_path("test-layers", "biome.png");
+        assert!(img_path.exists());
+    }
+
+    #[test]
+    fn round_trip_level() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        let micro_biome = make_test_biome_map();
+        let manifest = make_level_manifest();
+
+        store
+            .save_level("test-level", &micro_biome, &manifest)
+            .unwrap();
+
+        let (loaded_bm, loaded_manifest) = store.load_level("test-level").unwrap();
+        assert_eq!(loaded_manifest, manifest);
+        assert_eq!(loaded_bm.width, micro_biome.width);
+        assert_eq!(loaded_bm.biomes, micro_biome.biomes);
+    }
+
+    #[test]
+    fn list_layers_returns_saved_artifacts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        let biome_map = make_test_biome_map();
+        let river_network = make_test_river_network();
+        let lifegen = make_test_lifegen_data();
+        let images = HashMap::new();
+
+        let manifest_a = LayerManifest {
+            seed: 1,
+            ..make_layer_manifest()
+        };
+        let manifest_b = LayerManifest {
+            seed: 2,
+            ..make_layer_manifest()
+        };
+
+        store
+            .save_layers("alpha", &biome_map, &river_network, &lifegen, &images, &manifest_a)
+            .unwrap();
+        store
+            .save_layers("beta", &biome_map, &river_network, &lifegen, &images, &manifest_b)
+            .unwrap();
+
+        let listed = store.list_layers().unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].0, "alpha");
+        assert_eq!(listed[0].1.seed, 1);
+        assert_eq!(listed[1].0, "beta");
+        assert_eq!(listed[1].1.seed, 2);
+    }
+
+    #[test]
+    fn list_levels_returns_saved_artifacts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        let micro_biome = make_test_biome_map();
+        let manifest = make_level_manifest();
+
+        store
+            .save_level("level-one", &micro_biome, &manifest)
+            .unwrap();
+
+        let listed = store.list_levels().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].0, "level-one");
+        assert_eq!(listed[0].1.micro_coord, (4, 3));
+    }
+
+    #[test]
+    fn exists_returns_correct_values() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        assert!(!store.exists(ArtifactKind::Layers, "nonexistent"));
+
+        let biome_map = make_test_biome_map();
+        let river_network = make_test_river_network();
+        let lifegen = make_test_lifegen_data();
+        let images = HashMap::new();
+        let manifest = make_layer_manifest();
+
+        store
+            .save_layers("exists-test", &biome_map, &river_network, &lifegen, &images, &manifest)
+            .unwrap();
+
+        assert!(store.exists(ArtifactKind::Layers, "exists-test"));
+        assert!(!store.exists(ArtifactKind::Levels, "exists-test"));
+    }
+
+    #[test]
+    fn delete_removes_artifact() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        let biome_map = make_test_biome_map();
+        let river_network = make_test_river_network();
+        let lifegen = make_test_lifegen_data();
+        let images = HashMap::new();
+        let manifest = make_layer_manifest();
+
+        store
+            .save_layers("to-delete", &biome_map, &river_network, &lifegen, &images, &manifest)
+            .unwrap();
+        assert!(store.exists(ArtifactKind::Layers, "to-delete"));
+
+        store.delete(ArtifactKind::Layers, "to-delete").unwrap();
+        assert!(!store.exists(ArtifactKind::Layers, "to-delete"));
+    }
+
+    #[test]
+    fn delete_nonexistent_returns_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        let result = store.delete(ArtifactKind::Layers, "ghost");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn load_nonexistent_returns_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        let result = store.load_layers_data("missing");
+        assert!(result.is_err());
+
+        let result = store.load_level("missing");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn manifest_is_pretty_printed_ron() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = ArtifactStore::with_base_path(tmp.path().to_path_buf()).unwrap();
+
+        let biome_map = make_test_biome_map();
+        let river_network = make_test_river_network();
+        let lifegen = make_test_lifegen_data();
+        let images = HashMap::new();
+        let manifest = make_layer_manifest();
+
+        store
+            .save_layers("pretty-test", &biome_map, &river_network, &lifegen, &images, &manifest)
+            .unwrap();
+
+        let manifest_path = store
+            .artifact_dir(ArtifactKind::Layers, "pretty-test")
+            .join(MANIFEST_FILE);
+        let text = fs::read_to_string(manifest_path).unwrap();
+
+        // Pretty-printed RON should contain newlines and indentation
+        assert!(text.contains('\n'));
+        assert!(text.contains("seed"));
+        assert!(text.contains("42"));
+    }
+
+    #[test]
+    fn with_base_path_creates_directories() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = tmp.path().join("custom-root");
+        let _store = ArtifactStore::with_base_path(base.clone()).unwrap();
+
+        assert!(base.join("layers").exists());
+        assert!(base.join("levels").exists());
+    }
+}


### PR DESCRIPTION
## Summary

Creates the `rb_artifacts` crate that manages `~/.randlebrot/` for persistent layer and level artifacts. Closes #6.

## What's included

- `ArtifactStore` struct managing `~/.randlebrot/{layers,levels}/` directories
- Save/load for layer artifacts (BiomeMap + RiverNetwork + LifeGenData + PNG images)
- Save/load for level artifacts (micro BiomeMap)
- `LayerManifest` and `LevelManifest` as pretty-printed RON (human-readable)
- Listing, deletion, and existence checks
- Tag validation: alphanumeric + hyphens + underscores only
- 15 integration tests with tempdir isolation
- CLAUDE.md updated: crate map, dependency graph, artifact storage section
- Obsidian vault Randlebrot Engine doc updated with rb_artifacts bullet

## Design decisions

- **RiverNetwork stored separately from BiomeMap** — `BiomeMap.river_network` is `Arc<RiverNetwork>` and was marked `#[serde(skip)]` in PR #15, so they must be serialized as independent bincode files
- **Bincode for binary data** — fast, compact, lossless for f32/f64 arrays
- **RON for manifests** — human-readable, already used elsewhere in the project
- **`with_base_path()` constructor** — enables test isolation via tempdir without writing to real `~/.randlebrot/`
- **Images passed as `(width, height, rgba_bytes)`** — avoids dependency on specific image buffer types; callers provide raw RGBA data

## On-disk layout

```
~/.randlebrot/
├── layers/<tag>/
│   ├── manifest.ron
│   ├── macro_biome.bin
│   ├── river_network.bin
│   ├── lifegen.bin
│   └── images/*.png
└── levels/<tag>/
    ├── manifest.ron
    └── micro_biome.bin
```

## Acceptance criteria from issue

- [x] rb_artifacts crate exists in crates/, registered in workspace
- [x] ArtifactStore manages ~/.randlebrot/ base path
- [x] LayerManifest and LevelManifest as RON
- [x] save/load for layers and levels
- [x] list, delete, exists functions
- [x] Integration tests (15 tests, all passing)
- [x] Pretty-printed manifests
- [x] Descriptive errors
- [x] CLAUDE.md updated (crate map, dependency graph, artifact storage section)
- [x] Obsidian vault updated

## Test plan

- [x] `cargo test -p rb_artifacts` — 15 tests pass
- [x] `cargo clippy -p rb_artifacts -- -D warnings` — clean (only pre-existing workspace lint warning)
- [x] `cargo check` — full workspace compiles

🤖 Generated with [Claude Code](https://claude.ai/claude-code)