### PR TITLE
feat(cli): implement view layers/levels list and detail commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,7 @@ fn dir_size_bytes(path: &std::path::Path) -> u64 {
 }
 
 /// Format a byte count as a human-readable string (B / KB / MB / GB).
+/// GB and MB use one decimal place; KB and B use integer precision.
 fn format_bytes(bytes: u64) -> String {
     const KB: u64 = 1024;
     const MB: u64 = 1024 * KB;
@@ -182,7 +183,7 @@ fn format_bytes(bytes: u64) -> String {
     if bytes >= GB {
         format!("{:.1} GB", bytes as f64 / GB as f64)
     } else if bytes >= MB {
-        format!("{} MB", bytes / MB)
+        format!("{:.1} MB", bytes as f64 / MB as f64)
     } else if bytes >= KB {
         format!("{} KB", bytes / KB)
     } else {
@@ -204,15 +205,12 @@ fn format_timestamp(iso: &str) -> String {
     without_fraction.replacen('T', " ", 1)
 }
 
-/// Pad a string to exactly `width` characters with trailing spaces. If the
-/// string is already at or over the width, a single trailing space is added
-/// so adjacent columns never collide.
+/// Pad a string to exactly `width` characters with trailing spaces.
+/// If the string is already at or over `width`, no padding is added
+/// (callers pass `max_cell_length + 2` so this is effectively unreachable,
+/// but `saturating_sub` keeps it safe regardless).
 fn pad(s: &str, width: usize) -> String {
-    if s.len() >= width {
-        format!("{s} ")
-    } else {
-        format!("{s}{}", " ".repeat(width - s.len()))
-    }
+    format!("{s}{}", " ".repeat(width.saturating_sub(s.len())))
 }
 
 /// `randlebrot view layers` — print a formatted table of all layer artifacts.
@@ -338,15 +336,32 @@ fn view_level_detail(tag: &str) -> Result<(), String> {
     let store = rb_artifacts::ArtifactStore::new().map_err(|e| e.to_string())?;
 
     // `rb_artifacts::ArtifactStore` currently only exposes a full `load_level`
-    // (which deserializes the micro BiomeMap). Listing all levels and filtering
-    // by tag lets us fetch just the manifest cheaply without adding a new
-    // public method to rb_artifacts (keeps this PR scoped to src/main.rs).
+    // (which deserializes the micro BiomeMap) and no `load_level_manifest`
+    // helper (`load_layer_manifest` exists, but only for layer artifacts).
+    // Listing all levels and filtering by tag lets us fetch just the manifest
+    // cheaply without adding a new public method to rb_artifacts (keeps this
+    // PR scoped to src/main.rs). A future `load_level_manifest` could make
+    // this a single call.
     let entries = store.list_levels().map_err(|e| e.to_string())?;
     let manifest = entries
-        .into_iter()
+        .iter()
         .find(|(t, _)| t == tag)
-        .map(|(_, m)| m)
-        .ok_or_else(|| format!("level artifact '{tag}' not found"))?;
+        .map(|(_, m)| m.clone())
+        .ok_or_else(|| {
+            if entries.is_empty() {
+                format!(
+                    "level artifact '{tag}' not found (no levels exist — run \
+                     `randlebrot generate level <layers-tag|--seed N> <x,y> <tag>`)"
+                )
+            } else {
+                let available: Vec<&str> =
+                    entries.iter().map(|(t, _)| t.as_str()).collect();
+                format!(
+                    "level artifact '{tag}' not found. Available: {}",
+                    available.join(", ")
+                )
+            }
+        })?;
 
     let dir = store.base_path().join("levels").join(tag);
     let size = format_bytes(dir_size_bytes(&dir));
@@ -359,6 +374,13 @@ fn view_level_detail(tag: &str) -> Result<(), String> {
         None => format!("--seed {} (civ_seed={})", manifest.seed, manifest.civ_seed),
     };
 
+    // NOTE: `LevelManifest.micro_coord` semantics are not yet locked down —
+    // `generate level` is stubbed (see issue #7 / PR #19). This code assumes
+    // `micro_coord` is a global world-tile coordinate so that
+    // `mx * MICRO_WORLD_SIZE` yields the absolute world position. If a future
+    // `generate level` implementation populates it as a chunk coord (multiply
+    // by CHUNK_SIZE=64.0) or a local index within a meso tile (add meso
+    // origin), update this conversion to match.
     let (mx, my) = manifest.micro_coord;
     let world_x = mx as f64 * MICRO_WORLD_SIZE;
     let world_y = my as f64 * MICRO_WORLD_SIZE;


### PR DESCRIPTION
## Summary

Implements `view layers`, `view levels`, and `view levels <tag>` CLI commands. Closes #8.

## What's included

- `view layers`: formatted table of all layer artifacts with size on disk (TAG, SEED, CIV_SEED, CREATED, LAYERS, SIZE)
- `view levels`: formatted table of all level artifacts (TAG, SOURCE, COORD, CREATED), where SOURCE is the parent layers tag or `--seed N`
- `view levels <tag>`: detailed metadata block for one level (Tag / Source / Micro Coord / World Position / Created / Size)
- Sorted by creation date (newest first) — ISO 8601 lexicographic sort
- Empty state messages with actionable command suggestion
- Clean error + non-zero exit when a tag is not found
- Recursive directory size walk with human-readable B/KB/MB/GB formatting
- ISO 8601 timestamp pretty-printing (`2026-04-04T14:23:01Z` -> `2026-04-04 14:23:01`)
- Fully headless — no Bevy initialization, stdout-only

## Implementation notes

- Only the `View` subcommand arms are implemented. `Generate` arms remain stubbed — that's #7's scope.
- `view layers <tag>` is still stubbed as the interactive viewer is #9's scope.
- `rb_artifacts::ArtifactStore` exposes `load_layer_manifest` (cheap) but only `load_level` (which deserializes the micro BiomeMap). To keep this PR scoped to `src/main.rs`, `view levels <tag>` uses `list_levels()` and filters by tag — still cheap since listing only reads RON manifests. A future refactor could add `load_level_manifest` to `rb_artifacts`.
- **Coordinate discrepancy resolved:** The old CLAUDE.md text referenced `0.25` world units per micro tile, but the code (and current CLAUDE.md) uses `MICRO_WORLD_SIZE = 1.0`. The existing constant is reused for the `World Position` calculation, so no drift.
- **Docs:** CLAUDE.md `## Build & Run` already lists `view layers`, `view layers <tag>`, `view levels`, and `view levels <tag>` from a prior wave (lines 113-116), so no doc edit was needed.
- **Obsidian vault:** `Margin's Grip - Randlebrot Engine.md` already documents the CLI pipeline including these commands (section "CLI Interface", lines 71-74). No edit required.
- **Parallel coordination with #7:** This PR only touches the `View` match arms in `src/main.rs`. If #7 merges first and introduces conflicts in the `Generate` arms, this branch will need a rebase.

## Acceptance Criteria from Issue

- [x] `view layers` lists all artifacts
- [x] `view levels` lists all levels
- [x] `view levels <tag>` shows details
- [x] Empty state messages
- [x] Error on missing tag (prints to stderr, exit code 1)
- [x] Sorted by creation date (newest first)
- [x] Size on disk shown
- [x] Aligned terminal output

## Test plan

- [x] `cargo check --bin randlebrot` — passes
- [x] `cargo clippy --bin randlebrot -- -D warnings` — no new warnings
- [x] `cargo test --workspace` — 254 tests pass
- [x] Smoke test: `cargo run -- view layers` → "No layers generated yet..." message
- [x] Smoke test: `cargo run -- view levels` → "No levels generated yet..." message
- [x] Smoke test: `cargo run -- view levels nonexistent-tag` → "level artifact 'nonexistent-tag' not found", exit 1
- [x] Smoke test: `cargo run -- view layers some-tag` → still stubbed (reserved for #9)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)