### PR TITLE
Rewrite work-issues + explore-feature skills to use native sub-issues and dependencies

### DIFF
--- a/.claude/skills/explore-feature/SKILL.md
+++ b/.claude/skills/explore-feature/SKILL.md
@@ -82,24 +82,30 @@ are expressed via GitHub's native issue dependencies API, NOT via wave labels
 
 ### Rules for Decomposition
 
-1. **One parent per feature**. The parent issue describes the feature at a high
-   level (goal, design, acceptance at the feature level). It is NOT a work unit
-   — no agent will implement it directly. Its job is to track progress across
-   its sub-issues (GitHub auto-updates `sub_issues_summary`).
-2. **Sub-issues are the work units**. Each sub-issue is small enough for one
+1. **Stand-alone issues for trivial features**. If the feature is genuinely a
+   single small change (one function, one test, one config tweak, one doc
+   update), skip the parent entirely and create a single stand-alone issue.
+   Parents are only worth their overhead when there are 2+ sub-issues.
+   `/work-issues` handles stand-alone issues as first-class work units.
+2. **Otherwise: one parent per feature**. The parent issue describes the
+   feature at a high level (goal, design, acceptance at the feature level).
+   It is NOT a work unit — no agent will implement it directly. Its job is
+   to track progress across its sub-issues (GitHub auto-updates
+   `sub_issues_summary`).
+3. **Sub-issues are the work units**. Each sub-issue is small enough for one
    agent to implement in a single PR. If a sub-issue is too big, split it.
-3. **Dependencies via the native API**. If sub-issue B needs sub-issue A's
+4. **Dependencies via the native API**. If sub-issue B needs sub-issue A's
    output, encode it as `B.blocked_by = [A]` via the dependencies API. No
    "Depends on: #X" text in issue bodies — the API is the source of truth.
-4. **One crate per sub-issue where possible**. Respect the workspace crate
+5. **One crate per sub-issue where possible**. Respect the workspace crate
    boundary to maximise parallelism.
-5. **rb_core types before implementations**. Core traits/types are always early
+6. **rb_core types before implementations**. Core traits/types are always early
    sub-issues that later ones depend on.
-6. **Test in the same sub-issue**. Each sub-issue includes its own tests — no
+7. **Test in the same sub-issue**. Each sub-issue includes its own tests — no
    separate "add tests" sub-issues.
-7. **Debug layer verification**. If the feature produces visible terrain output,
+8. **Debug layer verification**. If the feature produces visible terrain output,
    the relevant sub-issue must include `save_debug_layers` integration.
-8. **No `wave-N` labels**. Waves are derived from the dependency graph at
+9. **No `wave-N` labels**. Waves are derived from the dependency graph at
    `/work-issues` discovery time. Agents never see wave numbers.
 
 ### Parent issue template
@@ -196,8 +202,31 @@ Use labels `randlebrot` and `feature`. **Do not create or use `wave-N` labels.**
 set -euo pipefail
 
 # Create GitHub parent + sub-issues for: $ARGUMENTS
+#
+# NOTE TO THE AGENT GENERATING THIS SCRIPT: every literal below
+# ("Wind system", sub-issue titles, body contents) is an example — replace
+# them with the real feature data from Phase 2. REPO should stay as-is.
 
 REPO="rjh-mopjones/randlebrot"
+CREATED_ISSUES=()
+
+# If anything fails partway through, close any issues we already created
+# so the repo is not left with orphan parents or disconnected sub-issues.
+cleanup_on_failure() {
+  local rc=$?
+  if [ $rc -ne 0 ] && [ ${#CREATED_ISSUES[@]} -gt 0 ]; then
+    echo "" >&2
+    echo "ERROR: script failed with exit code $rc, closing partially-created issues:" >&2
+    for n in "${CREATED_ISSUES[@]}"; do
+      echo "  closing #$n" >&2
+      gh issue close "$n" --repo "$REPO" \
+        --comment "Automated cleanup: creation script failed partway through." \
+        2>/dev/null || true
+    done
+  fi
+  return $rc
+}
+trap cleanup_on_failure EXIT
 
 # ---- Parent ----
 PARENT_URL=$(gh issue create --repo "$REPO" \
@@ -225,6 +254,7 @@ pressure differential...
 EOF
 )")
 PARENT_NUM=$(basename "$PARENT_URL")
+CREATED_ISSUES+=("$PARENT_NUM")
 PARENT_ID=$(gh api "/repos/$REPO/issues/$PARENT_NUM" --jq '.id')
 echo "Created parent #$PARENT_NUM (id=$PARENT_ID)"
 
@@ -254,6 +284,7 @@ Add a WindStrategy to rb_noise following the ContinentalnessStrategy pattern.
 EOF
 )")
 A_NUM=$(basename "$A_URL")
+CREATED_ISSUES+=("$A_NUM")
 A_ID=$(gh api "/repos/$REPO/issues/$A_NUM" --jq '.id')
 
 # Link as sub-issue of parent
@@ -272,6 +303,7 @@ B_URL=$(gh issue create --repo "$REPO" \
 EOF
 )")
 B_NUM=$(basename "$B_URL")
+CREATED_ISSUES+=("$B_NUM")
 B_ID=$(gh api "/repos/$REPO/issues/$B_NUM" --jq '.id')
 
 gh api --method POST "/repos/$REPO/issues/$PARENT_NUM/sub_issues" \
@@ -284,6 +316,10 @@ gh api --method POST "/repos/$REPO/issues/$B_NUM/dependencies/blocked_by" \
 echo "  #$B_NUM linked as sub-issue of #$PARENT_NUM, blocked by #$A_NUM"
 
 # ... continue for each sub-issue ...
+
+# All issues created successfully — disarm the cleanup trap so we don't
+# close the freshly-created issues on normal exit.
+trap - EXIT
 
 echo ""
 echo "Done. Run '/work-issues' to implement the ready sub-issues, or"

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -55,7 +55,11 @@ labels have been retired — never create them, never rely on them.
 ### 0a. Fetch all open issues (with sub-issue + dependency summaries)
 
 ```bash
+# --paginate concatenates all pages into a single JSON array, so we get
+# the full issue list regardless of repo size. Without it, the response
+# is capped at per_page (max 100) on page 1.
 gh api /repos/rjh-mopjones/randlebrot/issues \
+  --paginate \
   -X GET \
   -f state=open \
   -f per_page=100 \
@@ -178,12 +182,13 @@ import json, subprocess
 work_units = json.load(open('/tmp/rb_work_units.json'))
 
 enriched = []
+dep_api_failures = []
 for w in work_units:
     num = w['number']
 
     # Full body + labels
     result = subprocess.run(
-        ['gh', 'issue', 'view', str(num), '--json', 'number,title,body,labels,comments'],
+        ['gh', 'issue', 'view', str(num), '--json', 'number,title,body,labels'],
         capture_output=True, text=True
     )
     data = json.loads(result.stdout) if result.stdout.strip() else {}
@@ -193,11 +198,21 @@ for w in work_units:
         ['gh', 'api', f'/repos/rjh-mopjones/randlebrot/issues/{num}/dependencies/blocked_by'],
         capture_output=True, text=True
     )
-    blocked_by_raw = json.loads(result.stdout) if result.stdout.strip() else []
-    blocked_by = [
-        {'number': b['number'], 'state': b['state'], 'title': b['title']}
-        for b in blocked_by_raw
-    ]
+    if result.returncode != 0:
+        # Silent failure here would cause agents to run with unmet blockers.
+        # Record the failure and treat as "unknown blockers" (sentinel).
+        dep_api_failures.append((num, result.stderr.strip()))
+        blocked_by_raw = None
+    else:
+        blocked_by_raw = json.loads(result.stdout) if result.stdout.strip() else []
+
+    if blocked_by_raw is None:
+        blocked_by = None  # unknown — downstream will treat as NOT ready
+    else:
+        blocked_by = [
+            {'number': b['number'], 'state': b['state'], 'title': b['title']}
+            for b in blocked_by_raw
+        ]
 
     enriched.append({
         **w,
@@ -207,10 +222,18 @@ for w in work_units:
     })
 
     print(f"#{num}: {w['title']}")
-    if blocked_by:
+    if blocked_by is None:
+        print(f"    ! dependencies API failed — treating as blocked (unknown)")
+    elif blocked_by:
         for b in blocked_by:
             marker = '✓' if b['state'] == 'closed' else '⏳'
             print(f"    {marker} blocked by #{b['number']} ({b['state']}): {b['title']}")
+
+if dep_api_failures:
+    print(f"\nWARNING: {len(dep_api_failures)} dependency API call(s) failed:")
+    for num, err in dep_api_failures:
+        print(f"  #{num}: {err}")
+    print("  These issues will be treated as blocked (unknown state).")
 
 with open('/tmp/rb_issues_enriched.json', 'w') as f:
     json.dump(enriched, f, indent=2)
@@ -223,55 +246,69 @@ EOF
 
 ## Phase 2 — Build the dependency graph
 
-A work unit is **ready** if all its `blocked_by` dependencies are either:
-- Closed (merged) — the blocker is done
-- Not in the current work unit batch — presumably merged or outside scope
+A work unit is **ready** if ALL its `blocked_by` dependencies are closed.
+The native dependencies API returns each blocker's `state` field — that is
+the authoritative source, regardless of whether the blocker is in the current
+batch, in another feature's sub-issue tree, or claimed by an open PR.
 
 A work unit is **blocked** if any of its `blocked_by` dependencies is still
-open AND in the current batch.
+open, or if the Phase 1 API call to fetch its blockers failed (unknown state).
 
 ```bash
 python3 << 'EOF'
 import json
 
 enriched = json.load(open('/tmp/rb_issues_enriched.json'))
-batch_nums = {w['number'] for w in enriched}
 
 analysis = {}
 for w in enriched:
     num = w['number']
-    blockers_open_in_batch = [
-        b['number'] for b in w['blocked_by']
-        if b['state'] == 'open' and b['number'] in batch_nums
-    ]
+    blocked_by = w.get('blocked_by')
+
+    if blocked_by is None:
+        # Phase 1 failed to fetch — treat as blocked with unknown reason.
+        is_ready = False
+        blockers_still_open = []
+        unknown = True
+    else:
+        blockers_still_open = [
+            b for b in blocked_by if b['state'] == 'open'
+        ]
+        is_ready = len(blockers_still_open) == 0
+        unknown = False
+
     analysis[num] = {
         **w,
-        'blocked_by_in_batch': blockers_open_in_batch,
-        'ready': len(blockers_open_in_batch) == 0,
+        'blockers_still_open': blockers_still_open,
+        'ready': is_ready,
+        'blockers_unknown': unknown,
     }
 
-ready = [w for w in analysis.values() if w['ready']]
-blocked = [w for w in analysis.values() if not w['ready']]
+ready_list = [w for w in analysis.values() if w['ready']]
+blocked_list = [w for w in analysis.values() if not w['ready']]
 
 print("\n=== READY — CAN START NOW ===")
-for w in sorted(ready, key=lambda x: x['number']):
+for w in sorted(ready_list, key=lambda x: x['number']):
     parent = f' (sub-issue of #{w["parent_number"]})' if w['parent_number'] else ''
     print(f"  #{w['number']}: {w['title']}{parent}")
 
-print("\n=== BLOCKED — waiting on open blockers in this batch ===")
-for w in sorted(blocked, key=lambda x: x['number']):
-    deps = ', '.join(f"#{d}" for d in w['blocked_by_in_batch'])
+print("\n=== BLOCKED — waiting on open blockers ===")
+for w in sorted(blocked_list, key=lambda x: x['number']):
     parent = f' (sub-issue of #{w["parent_number"]})' if w['parent_number'] else ''
     print(f"  #{w['number']}: {w['title']}{parent}")
-    print(f"      blocked by: {deps}")
+    if w['blockers_unknown']:
+        print(f"      blocked by: (unknown — dependencies API call failed)")
+    else:
+        deps = ', '.join(f"#{b['number']}" for b in w['blockers_still_open'])
+        print(f"      blocked by: {deps}")
 
 with open('/tmp/rb_issues_ready.json', 'w') as f:
-    json.dump(ready, f, indent=2)
+    json.dump(ready_list, f, indent=2)
 
 with open('/tmp/rb_issues_all.json', 'w') as f:
     json.dump(list(analysis.values()), f, indent=2)
 
-print(f"\n{len(ready)} ready, {len(blocked)} blocked.")
+print(f"\n{len(ready_list)} ready, {len(blocked_list)} blocked.")
 EOF
 ```
 
@@ -385,9 +422,13 @@ in the PR body — the orchestrator will handle it separately. Do NOT fail the P
 
 ## Step 4 — Tests
 
+Always use `--workspace` to catch cross-crate breakage before raising the PR.
+An agent working in `rb_world` that only runs `cargo check` on the current
+package will miss failures in `rb_editor` or `src/main.rs` that CI will catch.
+
 ```bash
-cargo check 2>&1
-cargo clippy --bin randlebrot -- -D warnings 2>&1
+cargo check --workspace 2>&1
+cargo clippy --workspace --all-targets -- -D warnings 2>&1
 cargo test --workspace 2>&1
 ```
 
@@ -505,4 +546,6 @@ For failed agents, print the last few lines of their output for diagnosis.
 
 **Quirks**:
 - `sub_issue_id` and `issue_id` are the integer `id` field, NOT the issue number. Use `gh api -F` (typed) not `-f` (string).
-- DELETE on dependencies takes the integer id in the URL path.
+- DELETE on dependencies takes the integer id in the URL path: `DELETE /issues/N/dependencies/blocked_by/<id>`.
+- DELETE on sub-issues is **the opposite shape**: `DELETE /issues/N/sub_issue` (singular path segment!) takes `sub_issue_id` in the request body, not the URL. Watch out for the plural/singular mismatch with the POST endpoint.
+- The list endpoint (`GET /repos/{owner}/{repo}/issues`) returns `sub_issues_summary` and `parent_issue_url` fields inline, but `issue_dependencies_summary` may require the single-issue endpoint. Phase 1 always fetches blockers via the dedicated `/dependencies/blocked_by` endpoint, so this does not affect correctness.


### PR DESCRIPTION
## Summary

Replaces the ad-hoc `wave-N` label + "Depends on: #X" body-text system with GitHub's **native sub-issues** and **issue dependencies** APIs. Both verified working end-to-end via `gh api`.

## Background

When we set up the CLI feature, we used a hand-rolled dependency system:
- `wave-1` through `wave-5` labels to group issues into parallel batches
- "Depends on: #X" text in issue bodies, regex-parsed by the work-issues skill

This worked, but hit two real problems in practice:
1. **Issue body references used the wrong numbers.** The templates referenced design-phase numbers (`#1`-`#9`) that didn't match the actual GitHub issue numbers (`#4`-`#12`). The skill had to fall back to wave labels to recover.
2. **Waves are a coarse organising principle.** Issue #12 (GUI migration) was a single issue with ~5 distinct sub-tasks (auto-save, Open dialog, Save As dialog, save level from launcher, etc.) that would benefit from finer decomposition, but we had no good way to model that in flat issues.

## What's in this PR

**`work-issues` skill rewrite:**
- Discovery walks parent → sub-issue hierarchy
- Parents are **feature trackers** (skipped by agents) — their `sub_issues_summary` updates automatically as sub-issues close
- **Sub-issues** and **stand-alone issues** are the actual work units
- Dependency graph built from `GET /issues/{N}/dependencies/blocked_by` (native API) instead of regex-parsing issue bodies
- Waves are now **derived topologically** from the dep graph — no more `wave-N` labels on issues
- Optional `[parent-number]` argument to scope discovery to one feature's sub-issues

**`explore-feature` skill rewrite:**
- Phase 3 now produces a **parent issue + sub-issues** instead of flat issues with wave labels
- Output script wires everything up: creates parent, creates each sub-issue, links sub-issues via `POST /issues/{N}/sub_issues`, encodes dependencies via `POST /issues/{N}/dependencies/blocked_by`
- No more `wave-N` labels created or used
- Sub-issue template is slimmer (no "Wave" / "Depends on" / "Parallel with" fields — those are now API-native)

**Documented API quirks:**
- `sub_issue_id` and `issue_id` in POST bodies are the **integer `id` field**, NOT the issue number. Get via `gh api /repos/.../issues/N --jq .id`
- Use `gh api -F` (typed) not `-f` (string) — APIs reject strings for integer/boolean fields
- DELETE on dependencies uses the integer id in the URL: `DELETE /issues/N/dependencies/blocked_by/<id>`
- Sub-issues and dependencies are **separate systems** — sub-issues for decomposition, dependencies for sequencing

## Follow-up work (not in this PR)

1. Break down #11 (launch command) and #12 (GUI migration) into parent-issue + sub-issue trees using the new skill model
2. Retire the `wave-1` through `wave-5` labels from existing closed issues (keep them as historical markers on merged PRs, but don't create new ones)
3. Optionally: migrate #22 to reference #7 via the native dependencies API instead of "Depends on" body text

## Test plan

- [ ] Verify both skills appear in the available skills list after merge
- [ ] Run `/explore-feature` on a trivial feature to confirm the new output format generates valid parent + sub-issues
- [ ] Run `/work-issues` and confirm discovery walks parent → sub-issue hierarchy correctly and reads native dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)