### PR TITLE
feat(editor): save level artifacts from Level Launcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,35 +428,52 @@ World Map (F1)          Level Launcher (F4)
 │              │        │ GeneratingMeso: async 64-tile generation + bar   │
 │              │        │                                                  │
 │              │        │ MesoView: 8×8 meso grid, click to select tile   │
-│              │        │   └─▶ "Launch Level" button                      │
+│              │        │   └─▶ "Generate Micromap" button                 │
+│              │        │                                                  │
+│              │        │ GeneratingMicro: async 64-tile generation + bar  │
+│              │        │                                                  │
+│              │        │ MicroView: 8×8 micro grid, click to select tile  │
+│              │        │   └─▶ "Play" button + "Save Level" button        │
 │              │        │                                                  │
 │              │        │ Playing: micro chunks stream around player       │
-│              │        │   └─▶ ESC returns to MesoView (not full exit)   │
+│              │        │   └─▶ "Save Level" button                        │
+│              │        │   └─▶ ESC returns to MicroView (not full exit)   │
 └──────────────┘        └──────────────────────────────────────────────────┘
 ```
 
 **Phase flow:**
 1. **MacroView** — Shows the selected macro chunk enlarged (512px display). Side panel shows chunk coords and "Generate Mesomap" button.
 2. **GeneratingMeso** — Async generates all 64 meso tiles (8×8 grid within the chunk, each 8×8 world units at 512px, detail_level=2). Progress bar shown.
-3. **MesoView** — Displays the 8×8 meso grid. Hover highlights tiles, click to select. Side panel shows meso tile coords and "Launch Level" button.
-4. **Playing** — Micro-level chunks (detail_level=3) stream around the player. ESC returns to MesoView (meso sprites re-shown, not all the way back to world map).
+3. **MesoView** — Displays the 8×8 meso grid. Hover highlights tiles, click to select. Side panel shows meso tile coords and "Generate Micromap" button.
+4. **GeneratingMicro** — Async generates all 64 micro tiles (8×8 grid within the meso tile, each 1×1 world unit at 512px, detail_level=3). Progress bar shown.
+5. **MicroView** — Displays the 8×8 micro grid. Click to select a micro tile. Side panel shows micro tile coords, "Play" button, and "Save Level" button.
+6. **Playing** — Micro-level chunks (detail_level=3) stream around the player. "Save Level" button available. ESC returns to MicroView (micro sprites re-shown, not all the way back to world map).
+
+**Save Level** — Available in MicroView and Playing phases when a micro tile is selected. Prompts for a tag name, then persists the micro BiomeMap and a `LevelManifest` (with global micro coordinates) via `rb_artifacts::save_level()`. The local launcher coordinates (0..8 within meso) are converted to global CLI coordinates (0..1024, 0..512) using the macro chunk + meso tile offsets: `global_x = chunk_x * 64 + meso_x * 8 + micro_x`. Saved levels appear in `randlebrot view levels` output.
 
 **Key implementation details:**
 - World map pool sprites are hidden on `OnEnter(LevelLauncher)` and re-shown on `OnExit(LevelLauncher)`
 - Meso tiles are generated via `AsyncComputeTaskPool` with `MACRO_PREGEN_CONCURRENCY` parallelism
 - `MesoTileCache` stores generated textures; `MesoPregenState` tracks generation progress
-- Camera pan works in all launcher phases; zoom is available in MesoView
-- `LauncherMacroSprite`, `LauncherMesoSprite`, `MesoHighlight` entities are all cleaned up on exit
+- `MicroTileCache` stores generated micro textures + `Arc<BiomeMap>` for save
+- Camera pan works in all launcher phases; zoom is available in MesoView/MicroView
+- `LauncherMacroSprite`, `LauncherMesoSprite`, `LauncherMicroSprite`, `MesoHighlight`, `MicroHighlight` entities are all cleaned up on exit
 
 **Key types:**
 ```rust
-LauncherPhase        // MacroView | GeneratingMeso | MesoView | Playing
+LauncherPhase        // MacroView | GeneratingMeso | MesoView | GeneratingMicro | MicroView | Playing
 GenerateMesoRequest  // Signal resource: user clicked "Generate Mesomap"
-LaunchLevelRequest   // Signal resource: user clicked "Launch Level"
+LaunchLevelRequest   // Signal resource: user clicked "Generate Micromap"
+StartPlayRequest     // Signal resource: user clicked "Play"
+SaveLevelRequest     // Signal resource: user confirmed a level tag for save
+SaveLevelUiState     // UI state for the save dialog (tag input, status message)
 SelectedChunk        // Macro chunk selected on world map (chunk_coord, origin)
 SelectedMesoTile     // Meso tile selected in launcher grid (meso_coord, origin)
+SelectedMicroTile    // Micro tile selected in launcher grid (micro_coord, origin)
 MesoTileCache        // HashMap<(i32,i32), MesoCachedTile> + sprite entity list
+MicroTileCache       // HashMap<(i32,i32), MicroCachedTile> + sprite entity list
 MesoPregenState      // Tracks async meso generation (total, completed, remaining, in_flight)
+MicroPregenState     // Tracks async micro generation (total, completed, remaining, in_flight)
 PlayableLevel        // Active level state (origin, chunk_coord, seed, world_height)
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4756,6 +4756,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_egui",
+ "rb_artifacts",
  "rb_core",
  "rb_noise",
  "rb_persistence",

--- a/crates/rb_editor/Cargo.toml
+++ b/crates/rb_editor/Cargo.toml
@@ -9,6 +9,7 @@ rb_noise.workspace = true
 rb_world.workspace = true
 rb_tilemap.workspace = true
 rb_persistence.workspace = true
+rb_artifacts.workspace = true
 bevy.workspace = true
 bevy_egui.workspace = true
 

--- a/crates/rb_editor/src/launcher_ui.rs
+++ b/crates/rb_editor/src/launcher_ui.rs
@@ -15,6 +15,27 @@ pub struct LaunchLevelRequest;
 #[derive(Resource)]
 pub struct StartPlayRequest;
 
+/// Signal requesting the current micro tile be saved as a level artifact.
+///
+/// Emitted by the launcher UI when the user confirms a level tag.
+/// Consumed by a system in `main.rs` that has access to `MicroTileCache`.
+#[derive(Resource)]
+pub struct SaveLevelRequest {
+    /// User-chosen tag for the level artifact.
+    pub tag: String,
+}
+
+/// UI state for the "Save Level" dialog in the launcher panel.
+#[derive(Resource, Default)]
+pub struct SaveLevelUiState {
+    /// Whether the save dialog is currently open.
+    pub show_dialog: bool,
+    /// Tag text being edited by the user.
+    pub tag_input: String,
+    /// Status message after save attempt (message, is_error).
+    pub status: Option<(String, bool)>,
+}
+
 /// Launcher phase — tracks progression through the multi-step workflow.
 #[derive(Resource, Clone, Copy, PartialEq, Eq, Debug)]
 pub enum LauncherPhase {
@@ -41,6 +62,7 @@ pub fn launcher_ui_system(
     selected_micro: Option<Res<SelectedMicroTile>>,
     phase: Option<Res<LauncherPhase>>,
     playing: Option<Res<PlayableLevel>>,
+    mut save_state: ResMut<SaveLevelUiState>,
 ) {
     let ctx = contexts.ctx_mut().unwrap();
     let phase = phase.map(|p| *p).unwrap_or(LauncherPhase::MacroView);
@@ -117,14 +139,78 @@ pub fn launcher_ui_system(
                     } else {
                         ui.label("Click a micro tile to select it.");
                     }
+
+                    // Save Level button + dialog — visible when a micro tile is selected.
+                    if selected_micro.is_some() {
+                        save_level_ui(ui, &mut commands, &mut save_state);
+                    }
                 }
                 LauncherPhase::Playing => {
                     if playing.is_some() {
                         ui.label("Playing — press ESC to stop");
                     }
+
+                    // Save Level button + dialog — visible during play.
+                    if selected_micro.is_some() {
+                        save_level_ui(ui, &mut commands, &mut save_state);
+                    }
                 }
             }
         });
+}
+
+/// Shared "Save Level" UI rendered in both MicroView and Playing phases.
+fn save_level_ui(
+    ui: &mut egui::Ui,
+    commands: &mut Commands,
+    save_state: &mut SaveLevelUiState,
+) {
+    ui.separator();
+
+    // Show status message from previous save attempt.
+    if let Some((ref msg, is_error)) = save_state.status {
+        let color = if is_error {
+            egui::Color32::RED
+        } else {
+            egui::Color32::GREEN
+        };
+        ui.colored_label(color, msg.as_str());
+        ui.add_space(4.0);
+    }
+
+    if !save_state.show_dialog {
+        if ui.button("Save Level").clicked() {
+            save_state.show_dialog = true;
+            save_state.status = None;
+        }
+    } else {
+        ui.label("Level tag:");
+        ui.text_edit_singleline(&mut save_state.tag_input);
+
+        let tag_valid = !save_state.tag_input.is_empty()
+            && save_state.tag_input.chars().all(|c| {
+                c.is_ascii_alphanumeric() || c == '-' || c == '_'
+            });
+
+        ui.horizontal(|ui| {
+            if ui.add_enabled(tag_valid, egui::Button::new("Save")).clicked() {
+                commands.insert_resource(SaveLevelRequest {
+                    tag: save_state.tag_input.clone(),
+                });
+                save_state.show_dialog = false;
+            }
+            if ui.button("Cancel").clicked() {
+                save_state.show_dialog = false;
+            }
+        });
+
+        if !tag_valid && !save_state.tag_input.is_empty() {
+            ui.colored_label(
+                egui::Color32::YELLOW,
+                "Tag: alphanumeric, hyphens, underscores only",
+            );
+        }
+    }
 }
 
 /// ESC exits play mode back to meso view (not all the way out).
@@ -182,6 +268,7 @@ pub fn cleanup_on_exit(
     commands.remove_resource::<GenerateMesoRequest>();
     commands.remove_resource::<LaunchLevelRequest>();
     commands.remove_resource::<StartPlayRequest>();
+    commands.remove_resource::<SaveLevelRequest>();
 
     for entity in &level_chunks {
         commands.entity(entity).despawn();

--- a/crates/rb_editor/src/lib.rs
+++ b/crates/rb_editor/src/lib.rs
@@ -8,7 +8,7 @@ pub mod launcher_ui;
 pub mod scene_ui;
 
 pub use generator_ui::{CurrentLayer, GeneratorUiState, RegenerationRequest};
-pub use launcher_ui::{GenerateMesoRequest, LaunchLevelRequest, LauncherPhase, StartPlayRequest};
+pub use launcher_ui::{GenerateMesoRequest, LaunchLevelRequest, LauncherPhase, SaveLevelRequest, SaveLevelUiState, StartPlayRequest};
 pub use civ_ui::{CivUiState, CurrentLifeGenLayer, LifeGenLayer, OverlayState, RegenerateLifeGenRequest};
 pub use scene_ui::{CurrentSceneLayer, SceneLayer};
 
@@ -35,6 +35,8 @@ impl Plugin for RbEditorPlugin {
             .init_resource::<CurrentLifeGenLayer>()
             .init_resource::<OverlayState>()
             .init_resource::<RegenerateLifeGenRequest>()
+            // Launcher save-level UI state
+            .init_resource::<SaveLevelUiState>()
             // Scene inspector resources
             .init_resource::<CurrentSceneLayer>()
             // Mode bar (runs in all modes) — must run before side panels

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
 use rb_core::{AppMode, ModeTransitionEvent, PlayableLevel, SelectedChunk, SelectedMesoTile, SelectedMicroTile, TerrainQuery, WorldPos, handle_mode_shortcuts};
-use rb_editor::{CurrentLayer, CurrentLifeGenLayer, GenerateMesoRequest, GeneratorUiState, LaunchLevelRequest, LauncherPhase, LifeGenLayer, RegenerateLifeGenRequest, RegenerationRequest, StartPlayRequest};
+use rb_editor::{CurrentLayer, CurrentLifeGenLayer, GenerateMesoRequest, GeneratorUiState, LaunchLevelRequest, LauncherPhase, LifeGenLayer, RegenerateLifeGenRequest, RegenerationRequest, SaveLevelRequest, SaveLevelUiState, StartPlayRequest};
 use rb_noise::{BiomeMap, MesoTerrainView, NoiseBackend, NormalizationHints};
 use rb_player::Player;
 use rb_tilemap::{LevelChunk, LoadedChunks};
@@ -669,6 +669,12 @@ fn launch_gui(_layers_tag: Option<String>) {
             handle_start_play_request
                 .run_if(in_state(AppPhase::Ready)
                     .and(resource_exists::<StartPlayRequest>)),
+        )
+        // Launcher: save level artifact
+        .add_systems(Update,
+            handle_save_level_request
+                .run_if(in_state(AppPhase::Ready)
+                    .and(resource_exists::<SaveLevelRequest>)),
         )
         // Launcher: re-show micro grid when ESC returns from Playing
         .add_systems(Update,
@@ -3468,6 +3474,84 @@ fn reshow_micro_on_return(
     for entity in &micro_highlight {
         commands.entity(entity).insert(Visibility::Inherited);
     }
+}
+
+/// Handle "Save Level" request: extract the micro BiomeMap from cache,
+/// build a LevelManifest with global micro coordinates, and persist via rb_artifacts.
+fn handle_save_level_request(
+    mut commands: Commands,
+    request: Res<SaveLevelRequest>,
+    micro_cache: Option<Res<MicroTileCache>>,
+    selected_micro: Option<Res<SelectedMicroTile>>,
+    selected_meso: Option<Res<SelectedMesoTile>>,
+    selected_chunk: Option<Res<SelectedChunk>>,
+    world_def: Res<WorldDefinition>,
+    mut save_ui: ResMut<SaveLevelUiState>,
+) {
+    // Always consume the request this frame.
+    let tag = request.tag.clone();
+    commands.remove_resource::<SaveLevelRequest>();
+
+    // Validate we have all the data we need.
+    let (Some(micro_cache), Some(selected_micro), Some(selected_meso), Some(selected_chunk)) =
+        (micro_cache, selected_micro, selected_meso, selected_chunk)
+    else {
+        save_ui.status = Some(("No micro tile data available".to_string(), true));
+        return;
+    };
+
+    let local_coord = selected_micro.micro_coord;
+    let Some(cached_tile) = micro_cache.tiles.get(&local_coord) else {
+        save_ui.status = Some((format!("Micro tile ({}, {}) not in cache", local_coord.0, local_coord.1), true));
+        return;
+    };
+
+    // Convert local launcher coords to global CLI micro coords.
+    // global_x = macro_chunk_x * 64 + meso_local_x * 8 + micro_local_x
+    // global_y = macro_chunk_y * 64 + meso_local_y * 8 + micro_local_y
+    // (64 = CHUNK_SIZE in world units, 8 = MESO_WORLD_SIZE, 1 = MICRO_WORLD_SIZE)
+    let (chunk_x, chunk_y) = selected_chunk.chunk_coord;
+    let (meso_x, meso_y) = selected_meso.meso_coord;
+    let (micro_x, micro_y) = local_coord;
+    // CHUNK_SIZE_I (64) = MESO_GRID_SIZE (8) * MICRO_GRID_SIZE (8) micro tiles across a macro chunk.
+    let global_micro_x = chunk_x * CHUNK_SIZE_I as i32 + meso_x * MICRO_GRID_SIZE + micro_x;
+    let global_micro_y = chunk_y * CHUNK_SIZE_I as i32 + meso_y * MICRO_GRID_SIZE + micro_y;
+
+    let manifest = rb_artifacts::LevelManifest {
+        parent_layers_tag: None,
+        seed: world_def.seed,
+        civ_seed: world_def.civ_seed,
+        micro_coord: (global_micro_x, global_micro_y),
+        created: chrono_timestamp(),
+    };
+
+    // Save via rb_artifacts.
+    match rb_artifacts::ArtifactStore::new() {
+        Ok(store) => {
+            match store.save_level(&tag, &cached_tile._biome_map, &manifest) {
+                Ok(()) => {
+                    println!(
+                        "Saved level artifact '{}' at global micro ({}, {})",
+                        tag, global_micro_x, global_micro_y,
+                    );
+                    save_ui.status = Some((format!("Saved as '{tag}'"), false));
+                }
+                Err(e) => {
+                    eprintln!("Failed to save level artifact: {e}");
+                    save_ui.status = Some((format!("Save failed: {e}"), true));
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to open artifact store: {e}");
+            save_ui.status = Some((format!("Store error: {e}"), true));
+        }
+    }
+}
+
+/// Generate an ISO 8601 timestamp string for manifest creation times.
+fn chrono_timestamp() -> String {
+    chrono::Utc::now().to_rfc3339()
 }
 
 /// Clean up all launcher-specific entities when leaving LevelLauncher mode.


### PR DESCRIPTION
Adds Save Level button to Level Launcher F4 in MicroView and Playing phases. Persists micro BiomeMap and LevelManifest via rb_artifacts with global coordinate conversion. Closes #28