### PR TITLE
feat(editor): add Open and Save As dialogs to editor UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,7 +441,7 @@ The editor loads and saves through `rb_artifacts`. After generating a world in t
 
 ### Mode Transitions
 - **F1-F4** keys switch between modes instantly
-- **World Generator** (F1): Generate procedural world, adjust noise params, save/load world definitions
+- **World Generator** (F1): Generate procedural world, adjust noise params, save/load world definitions. "Open Artifact..." lists available layer artifacts and loads one (replacing the current world via the `LoadingArtifact` path). "Save As Artifact..." saves the current world under a new tag via `rb_artifacts` (available only when a world is generated).
 - **World Map Editor** (F2): Place cities/landmarks, draw region polygons, view overlays
 - **Chunk Editor** (F3): Select chunk from map (Ctrl+Click), edit tiles and entities
 - **Level Launcher** (F4): Multi-step drill-down from macro chunk to playable level (see below)

--- a/crates/rb_editor/Cargo.toml
+++ b/crates/rb_editor/Cargo.toml
@@ -9,6 +9,7 @@ rb_noise.workspace = true
 rb_world.workspace = true
 rb_tilemap.workspace = true
 rb_persistence.workspace = true
+rb_artifacts.workspace = true
 bevy.workspace = true
 bevy_egui.workspace = true
 

--- a/crates/rb_editor/src/generator_ui.rs
+++ b/crates/rb_editor/src/generator_ui.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy_egui::{egui, EguiContexts};
+use rb_artifacts::LayerManifest;
 use rb_core::AppMode;
 use rb_noise::{NoiseBackend, NoiseLayer};
 use rb_persistence::{list_worlds, load_world, save_world, world_path};
@@ -34,6 +35,24 @@ pub struct GeneratorUiState {
     pub layer_changed: Option<NoiseLayer>,
     /// Whether to use GPU for noise generation (defaults to true).
     pub use_gpu: bool,
+    /// Whether the Open Artifact dialog is shown.
+    pub show_open_artifact_dialog: bool,
+    /// Cached list of available layer artifacts (fetched on dialog open).
+    pub available_artifacts: Vec<(String, LayerManifest)>,
+    /// Error message from listing artifacts.
+    pub artifact_list_error: Option<String>,
+    /// Whether the Save As Artifact dialog is shown.
+    pub show_save_as_dialog: bool,
+    /// Tag input for Save As dialog.
+    pub save_as_tag_input: String,
+    /// Error message for Save As dialog.
+    pub save_as_error: Option<String>,
+    /// Whether a Save As operation is in progress.
+    pub save_as_in_progress: bool,
+    /// Whether to confirm overwriting an existing artifact.
+    pub save_as_confirm_overwrite: bool,
+    /// Whether a generated world is available (AppPhase::Ready). Set by main.rs.
+    pub world_ready: bool,
 }
 
 impl Default for GeneratorUiState {
@@ -47,8 +66,33 @@ impl Default for GeneratorUiState {
             current_layer: None,
             layer_changed: None,
             use_gpu: true,
+            show_open_artifact_dialog: false,
+            available_artifacts: Vec::new(),
+            artifact_list_error: None,
+            show_save_as_dialog: false,
+            save_as_tag_input: String::new(),
+            save_as_error: None,
+            save_as_in_progress: false,
+            save_as_confirm_overwrite: false,
+            world_ready: false,
         }
     }
+}
+
+/// Signal resource: user selected an artifact to load from the Open dialog.
+/// main.rs consumes this and transitions to LoadingArtifact phase.
+#[derive(Resource)]
+pub struct OpenArtifactRequest {
+    /// Tag of the artifact to load.
+    pub tag: String,
+}
+
+/// Signal resource: user confirmed Save As with a tag name.
+/// main.rs consumes this and performs the save.
+#[derive(Resource)]
+pub struct SaveAsArtifactRequest {
+    /// Tag to save under.
+    pub tag: String,
 }
 
 impl GeneratorUiState {
@@ -94,6 +138,7 @@ pub fn terrain_panel_system(
     mut world_def: ResMut<WorldDefinition>,
     mut ui_state: ResMut<GeneratorUiState>,
     mut regen_request: ResMut<RegenerationRequest>,
+    mut commands: Commands,
 ) {
     // Initialize seed text from world definition
     if !ui_state.initialized {
@@ -222,6 +267,50 @@ pub fn terrain_panel_system(
                 ui_state.available_worlds = list_worlds().unwrap_or_default();
             }
 
+            ui.add_space(16.0);
+            ui.separator();
+
+            // Artifact Open/Save As buttons
+            ui.heading("Artifacts");
+            ui.add_space(4.0);
+
+            if ui.button("Open Artifact...").clicked() {
+                ui_state.show_open_artifact_dialog = true;
+                ui_state.artifact_list_error = None;
+                // Fetch the artifact list from disk.
+                match rb_artifacts::ArtifactStore::new() {
+                    Ok(store) => match store.list_layers() {
+                        Ok(list) => ui_state.available_artifacts = list,
+                        Err(e) => {
+                            ui_state.artifact_list_error =
+                                Some(format!("Failed to list artifacts: {e}"));
+                            ui_state.available_artifacts = Vec::new();
+                        }
+                    },
+                    Err(e) => {
+                        ui_state.artifact_list_error =
+                            Some(format!("Failed to open artifact store: {e}"));
+                        ui_state.available_artifacts = Vec::new();
+                    }
+                }
+            }
+
+            let save_as_enabled = ui_state.world_ready;
+            ui.add_enabled_ui(save_as_enabled, |ui| {
+                if ui
+                    .button("Save As Artifact...")
+                    .on_disabled_hover_text("Generate a world first")
+                    .clicked()
+                {
+                    ui_state.show_save_as_dialog = true;
+                    ui_state.save_as_error = None;
+                    ui_state.save_as_in_progress = false;
+                    ui_state.save_as_confirm_overwrite = false;
+                    // Pre-fill with sanitised world name.
+                    ui_state.save_as_tag_input = sanitize_tag_for_ui(&world_def.name);
+                }
+            });
+
             // Status message
             if let Some((msg, _)) = &ui_state.status_message {
                 ui.add_space(8.0);
@@ -316,6 +405,217 @@ pub fn terrain_panel_system(
                 }
             }
         }
+    }
+
+    // Open Artifact dialog window
+    if ui_state.show_open_artifact_dialog {
+        let mut close_dialog = false;
+        let mut selected_tag: Option<String> = None;
+
+        egui::Window::new("Open Layer Artifact")
+            .collapsible(false)
+            .resizable(true)
+            .default_size([420.0, 300.0])
+            .show(contexts.ctx_mut().unwrap(), |ui| {
+                ui.label("Select a layer artifact to load:");
+                ui.add_space(4.0);
+
+                if let Some(ref err) = ui_state.artifact_list_error {
+                    ui.label(
+                        egui::RichText::new(err)
+                            .color(egui::Color32::from_rgb(255, 100, 100))
+                            .size(12.0),
+                    );
+                    ui.add_space(8.0);
+                }
+
+                ui.separator();
+
+                egui::ScrollArea::vertical()
+                    .max_height(220.0)
+                    .show(ui, |ui| {
+                        if ui_state.available_artifacts.is_empty()
+                            && ui_state.artifact_list_error.is_none()
+                        {
+                            ui.label("No layer artifacts found.");
+                            ui.add_space(4.0);
+                            ui.label(
+                                egui::RichText::new(
+                                    "Generate a world via CLI or editor to create one.",
+                                )
+                                .size(11.0)
+                                .color(egui::Color32::GRAY),
+                            );
+                        }
+
+                        for (tag, manifest) in &ui_state.available_artifacts {
+                            ui.horizontal(|ui| {
+                                let label = format!(
+                                    "{tag}  (seed: {}, {}x{}, {})",
+                                    manifest.seed,
+                                    manifest.world_width,
+                                    manifest.world_height,
+                                    &manifest.created[..10.min(manifest.created.len())],
+                                );
+                                if ui.selectable_label(false, label).clicked() {
+                                    selected_tag = Some(tag.clone());
+                                    close_dialog = true;
+                                }
+                            });
+                        }
+                    });
+
+                ui.separator();
+                if ui.button("Cancel").clicked() {
+                    close_dialog = true;
+                }
+            });
+
+        if close_dialog {
+            ui_state.show_open_artifact_dialog = false;
+        }
+
+        if let Some(tag) = selected_tag {
+            commands.insert_resource(OpenArtifactRequest { tag });
+            ui_state.show_open_artifact_dialog = false;
+        }
+    }
+
+    // Save As Artifact dialog window
+    if ui_state.show_save_as_dialog {
+        let mut close_dialog = false;
+        let mut do_save = false;
+
+        egui::Window::new("Save As Layer Artifact")
+            .collapsible(false)
+            .resizable(false)
+            .default_size([380.0, 160.0])
+            .show(contexts.ctx_mut().unwrap(), |ui| {
+                ui.vertical(|ui| {
+                    ui.label("Save the current world as a layer artifact.");
+                    ui.add_space(8.0);
+
+                    ui.horizontal(|ui| {
+                        ui.label("Tag:");
+                        ui.text_edit_singleline(&mut ui_state.save_as_tag_input);
+                    });
+                    ui.add_space(4.0);
+
+                    ui.label(
+                        egui::RichText::new(
+                            "Letters, numbers, hyphens, and underscores only.",
+                        )
+                        .size(11.0)
+                        .color(egui::Color32::GRAY),
+                    );
+
+                    if let Some(ref err) = ui_state.save_as_error {
+                        ui.add_space(4.0);
+                        ui.label(
+                            egui::RichText::new(err)
+                                .color(egui::Color32::from_rgb(255, 100, 100))
+                                .size(12.0),
+                        );
+                    }
+
+                    if ui_state.save_as_confirm_overwrite {
+                        ui.add_space(4.0);
+                        ui.label(
+                            egui::RichText::new(format!(
+                                "Artifact '{}' already exists. Overwrite?",
+                                ui_state.save_as_tag_input.trim()
+                            ))
+                            .color(egui::Color32::from_rgb(255, 200, 80))
+                            .size(12.0),
+                        );
+                        ui.horizontal(|ui| {
+                            if ui.button("Overwrite").clicked() {
+                                do_save = true;
+                                ui_state.save_as_confirm_overwrite = false;
+                            }
+                            if ui.button("Cancel").clicked() {
+                                ui_state.save_as_confirm_overwrite = false;
+                            }
+                        });
+                    } else {
+                        ui.add_space(8.0);
+                        ui.horizontal(|ui| {
+                            let can_save = !ui_state.save_as_in_progress;
+                            ui.add_enabled_ui(can_save, |ui| {
+                                if ui.button("Save").clicked() {
+                                    let tag = ui_state.save_as_tag_input.trim().to_string();
+                                    // Validate tag
+                                    if tag.is_empty() {
+                                        ui_state.save_as_error =
+                                            Some("Tag must not be empty.".to_string());
+                                    } else if !tag.chars().all(|c| {
+                                        c.is_ascii_alphanumeric() || c == '-' || c == '_'
+                                    }) {
+                                        ui_state.save_as_error = Some(
+                                            "Tag must contain only letters, numbers, hyphens, and underscores.".to_string(),
+                                        );
+                                    } else {
+                                        // Check if it already exists
+                                        let exists = rb_artifacts::ArtifactStore::new()
+                                            .map(|s| {
+                                                s.exists(rb_artifacts::ArtifactKind::Layers, &tag)
+                                            })
+                                            .unwrap_or(false);
+                                        if exists {
+                                            ui_state.save_as_confirm_overwrite = true;
+                                            ui_state.save_as_error = None;
+                                        } else {
+                                            do_save = true;
+                                        }
+                                    }
+                                }
+                            });
+                            if ui.button("Cancel").clicked() {
+                                close_dialog = true;
+                            }
+                        });
+                    }
+
+                    if ui_state.save_as_in_progress {
+                        ui.add_space(4.0);
+                        ui.label("Saving...");
+                    }
+                });
+            });
+
+        if close_dialog {
+            ui_state.show_save_as_dialog = false;
+            ui_state.save_as_error = None;
+            ui_state.save_as_confirm_overwrite = false;
+        }
+
+        if do_save {
+            let tag = ui_state.save_as_tag_input.trim().to_string();
+            ui_state.save_as_in_progress = true;
+            ui_state.save_as_error = None;
+            commands.insert_resource(SaveAsArtifactRequest { tag });
+        }
+    }
+}
+
+/// Sanitise a string into a valid artifact tag for the UI.
+fn sanitize_tag_for_ui(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c.to_ascii_lowercase()
+            } else if c == ' ' {
+                '-'
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "world".to_string()
+    } else {
+        sanitized
     }
 }
 

--- a/crates/rb_editor/src/lib.rs
+++ b/crates/rb_editor/src/lib.rs
@@ -7,7 +7,7 @@ pub mod generator_ui;
 pub mod launcher_ui;
 pub mod scene_ui;
 
-pub use generator_ui::{CurrentLayer, GeneratorUiState, RegenerationRequest};
+pub use generator_ui::{CurrentLayer, GeneratorUiState, OpenArtifactRequest, RegenerationRequest, SaveAsArtifactRequest};
 pub use launcher_ui::{GenerateMesoRequest, LaunchLevelRequest, LauncherPhase, SaveLevelRequest, SaveLevelUiState, StartPlayRequest};
 pub use civ_ui::{CivUiState, CurrentLifeGenLayer, LifeGenLayer, OverlayState, RegenerateLifeGenRequest};
 pub use scene_ui::{CurrentSceneLayer, SceneLayer};

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
 use rb_core::{AppMode, ModeTransitionEvent, PlayableLevel, SelectedChunk, SelectedMesoTile, SelectedMicroTile, TerrainQuery, WorldPos, handle_mode_shortcuts};
-use rb_editor::{CurrentLayer, CurrentLifeGenLayer, GenerateMesoRequest, GeneratorUiState, LaunchLevelRequest, LauncherPhase, LifeGenLayer, RegenerateLifeGenRequest, RegenerationRequest, SaveLevelRequest, SaveLevelUiState, StartPlayRequest};
+use rb_editor::{CurrentLayer, CurrentLifeGenLayer, GenerateMesoRequest, GeneratorUiState, LaunchLevelRequest, LauncherPhase, LifeGenLayer, OpenArtifactRequest, RegenerateLifeGenRequest, RegenerationRequest, SaveAsArtifactRequest, SaveLevelRequest, SaveLevelUiState, StartPlayRequest};
 use rb_noise::{BiomeMap, MesoTerrainView, NoiseBackend, NormalizationHints};
 use rb_player::Player;
 use rb_tilemap::{LevelChunk, LoadedChunks};
@@ -745,7 +745,20 @@ fn launch_gui(layers_tag: Option<String>) {
         .add_systems(Update,
             artifact_load_system
                 .run_if(in_state(AppPhase::LoadingArtifact)),
-        );
+        )
+        // Open Artifact request (from editor UI) — transition to LoadingArtifact
+        .add_systems(Update,
+            handle_open_artifact_request
+                .run_if(resource_exists::<OpenArtifactRequest>),
+        )
+        // Save As Artifact request (from editor UI) — save current state
+        .add_systems(Update,
+            handle_save_as_artifact_request
+                .run_if(in_state(AppPhase::Ready)
+                    .and(resource_exists::<SaveAsArtifactRequest>)),
+        )
+        // Sync world_ready flag on GeneratorUiState
+        .add_systems(Update, sync_world_ready_flag);
 
     // If a layers tag was provided, insert it as a resource so the
     // LoadingArtifact system can read it.
@@ -2246,6 +2259,78 @@ fn artifact_load_system(
     println!("Artifact loaded. Pre-generating {} macro tile textures...", total);
 }
 
+// ─── Open / Save As Artifact (editor UI) ───────────────────────────────────
+
+/// Handle the OpenArtifactRequest signal from the editor UI.
+/// Inserts `LoadLayersTag` and transitions to `LoadingArtifact` phase.
+fn handle_open_artifact_request(
+    mut commands: Commands,
+    mut next_phase: ResMut<NextState<AppPhase>>,
+    request: Res<OpenArtifactRequest>,
+) {
+    let tag = request.tag.clone();
+    println!("Opening artifact '{tag}' from editor UI...");
+    commands.insert_resource(LoadLayersTag(tag));
+    commands.remove_resource::<OpenArtifactRequest>();
+    next_phase.set(AppPhase::LoadingArtifact);
+}
+
+/// Handle the SaveAsArtifactRequest signal from the editor UI.
+/// Performs the save synchronously reusing `perform_artifact_save`.
+fn handle_save_as_artifact_request(
+    mut commands: Commands,
+    request: Res<SaveAsArtifactRequest>,
+    macro_biome: Option<Res<MacroBiomeData>>,
+    global_rivers: Option<Res<GlobalRiverNetwork>>,
+    lifegen: Option<Res<LifeGenData>>,
+    tile_cache: Option<Res<TileCache>>,
+    norm_hints: Option<Res<GlobalNormHints>>,
+    world_def: Res<WorldDefinition>,
+    mut ui_state: ResMut<GeneratorUiState>,
+) {
+    let tag = request.tag.clone();
+    commands.remove_resource::<SaveAsArtifactRequest>();
+
+    let save_result = perform_artifact_save(
+        &tag,
+        macro_biome.as_deref(),
+        global_rivers.as_deref(),
+        lifegen.as_deref(),
+        tile_cache.as_deref(),
+        norm_hints.as_deref(),
+        &world_def,
+        &ui_state,
+    );
+
+    match save_result {
+        Ok(path) => {
+            println!("Artifact saved to {path}");
+            ui_state.show_save_as_dialog = false;
+            ui_state.save_as_in_progress = false;
+            ui_state.save_as_error = None;
+            ui_state.save_as_confirm_overwrite = false;
+            ui_state.status_message = Some((format!("Saved artifact '{tag}'"), 3.0));
+        }
+        Err(err) => {
+            eprintln!("Save As failed: {err}");
+            ui_state.save_as_in_progress = false;
+            ui_state.save_as_error = Some(err);
+        }
+    }
+}
+
+/// Sync the `world_ready` flag on `GeneratorUiState` based on whether
+/// the app is in `AppPhase::Ready` (i.e. a generated world exists).
+fn sync_world_ready_flag(
+    phase: Res<State<AppPhase>>,
+    mut ui_state: ResMut<GeneratorUiState>,
+) {
+    let ready = *phase.get() == AppPhase::Ready;
+    if ui_state.world_ready != ready {
+        ui_state.world_ready = ready;
+    }
+}
+
 /// Show progress bar during meso tile pre-generation.
 fn meso_pregen_progress_ui(
     mut contexts: EguiContexts,
@@ -3548,7 +3633,7 @@ fn poll_meso_pregen(
             let image = create_image(TILE_MAP_SIZE, TILE_MAP_SIZE, image_data);
             let texture = images.add(image);
 
-            meso_cache.tiles.insert(coord, MesoCachedTile { biome_map: biome_map, texture });
+            meso_cache.tiles.insert(coord, MesoCachedTile { biome_map, texture });
             pregen.completed += 1;
         } else {
             i += 1;
@@ -3826,7 +3911,7 @@ fn poll_micro_pregen(
             let image = create_image(TILE_MAP_SIZE, TILE_MAP_SIZE, image_data);
             let texture = images.add(image);
 
-            micro_cache.tiles.insert(coord, MicroCachedTile { biome_map: biome_map, texture });
+            micro_cache.tiles.insert(coord, MicroCachedTile { biome_map, texture });
             pregen.completed += 1;
         } else {
             i += 1;


### PR DESCRIPTION
## Summary

- Add "Open Artifact..." button to F1 generator panel that lists available layer artifacts (tag, seed, dimensions, date) and loads the selected one, replacing the current world via the `LoadingArtifact` phase
- Add "Save As Artifact..." button (enabled only when a world is generated) that prompts for a tag name with validation, overwrite confirmation, then saves via the existing `perform_artifact_save()` path
- Add `OpenArtifactRequest` and `SaveAsArtifactRequest` signal resources following the existing request pattern (editor crate inserts, main.rs consumes)
- Sync `world_ready` flag on `GeneratorUiState` from `AppPhase::Ready` so Save As is correctly disabled before generation
- Fix pre-existing clippy `redundant-field-names` warnings in meso/micro tile cache insertion

Closes #27.
Parent: #12.

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] Launch editor (`cargo run --release`), verify Open Artifact and Save As Artifact buttons appear in F1 panel
- [ ] Open Artifact: click button, verify artifact list populates, select one, verify world loads
- [ ] Save As Artifact: generate a world, click button, enter tag, save, verify artifact appears in `~/.randlebrot/layers/`
- [ ] Save As Artifact: try saving with an existing tag, verify overwrite confirmation appears
- [ ] Save As Artifact: verify button is disabled before world generation
- [ ] Tag validation: empty tag, invalid characters (spaces, dots, slashes) show error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)