### PR TITLE
feat(cli): add --flythrough flag for automated visual testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ cargo run -- view levels level-tag               # inspect a specific level arti
 
 # ─── Launch playable level (Comanche-style 3D terrain) ───
 cargo run -- launch level-tag                    # 3D terrain flyover via rb_voxel raycaster
-cargo run -- launch level-tag --flythrough       # automated flythrough → screenshots in /tmp/randlebrot_flythrough/
+cargo run --release -- launch level-tag --flythrough   # automated flythrough → screenshots in /tmp/randlebrot_flythrough/
 
 # ─── Tests & examples ───
 cargo test                                       # workspace tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ cargo run -- view levels level-tag               # inspect a specific level arti
 
 # ─── Launch playable level (Comanche-style 3D terrain) ───
 cargo run -- launch level-tag                    # 3D terrain flyover via rb_voxel raycaster
+cargo run -- launch level-tag --flythrough       # automated flythrough → screenshots in /tmp/randlebrot_flythrough/
 
 # ─── Tests & examples ───
 cargo test                                       # workspace tests
@@ -226,6 +227,8 @@ Always use `--release` — debug builds are unacceptably slow (tile generation d
 - Egui HUD (non-interactive, top-left) shows level tag, coordinate, seed, player world position, camera mode, draw distance, and FPS.
 
 **Implementation**: `src/commands/launch.rs`. Standalone Bevy app with `Camera3d`, directional light, ambient light, distance fog. Chunks stream via async `BiomeMap` generation → `build_local_heightmap()` (derives from base noise layers, not the flat derived heightmap) → `generate_chunk_mesh()` (local normalization + block face quad generation) → `Mesh3d` entity spawn. On macOS Sequoia, a `.app` bundle trampoline at `/tmp/Randlebrot.app` is used to acquire keyboard focus.
+
+**Flythrough mode**: `randlebrot launch <tag> --flythrough` runs an automated camera path through 10 waypoints (spawn view, rotations, movement, elevation changes), captures a screenshot at each waypoint via Bevy's `Screenshot` API, saves them to `/tmp/randlebrot_flythrough/frame_NNN.png`, and auto-exits. No cursor grab, no HUD, no manual input. The macOS `.app` trampoline is skipped in flythrough mode. Total duration is approximately 8 seconds. **Visual changes to the launcher MUST be verified via flythrough** — run `cargo run --release -- launch <tag> --flythrough` and inspect the output frames.
 
 ## Workspace Crate Map
 

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -14,12 +14,14 @@
 //!   ESC             — exit
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use bevy::app::AppExit;
 use bevy::input::mouse::{MouseMotion, MouseScrollUnit, MouseWheel};
 use bevy::prelude::*;
 use bevy::mesh::Indices;
+use bevy::render::view::screenshot::{save_to_disk, Screenshot};
 use bevy::tasks::{AsyncComputeTaskPool, Task, block_on, poll_once};
 use bevy::window::{CursorGrabMode, CursorOptions, PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
@@ -119,9 +121,11 @@ pub(crate) fn macos_ensure_app_bundle(args: &[String]) {
 
 // ─── Entry Point ───────────────────────────────────────────────────────────
 
-pub fn run(level_tag: String) -> Result<(), String> {
+pub fn run(level_tag: String, flythrough: bool) -> Result<(), String> {
     #[cfg(target_os = "macos")]
-    macos_ensure_app_bundle(&std::env::args().collect::<Vec<_>>());
+    if !flythrough {
+        macos_ensure_app_bundle(&std::env::args().collect::<Vec<_>>());
+    }
 
     // Validate tag exists
     let store = ArtifactStore::new()
@@ -155,17 +159,30 @@ pub fn run(level_tag: String) -> Result<(), String> {
 
     app.insert_resource(LaunchParams { level_tag });
 
-    app.add_systems(Startup, (setup_scene, grab_cursor));
-
     let loaded = resource_exists::<PlayerState>;
-    app.add_systems(Update, (
-        camera_input.run_if(loaded),
-        chunk_stream.run_if(loaded),
-        chunk_poll.run_if(loaded),
-        chunk_unload.run_if(loaded),
-        hud_system.run_if(loaded),
-        exit_on_esc,
-    ));
+
+    if flythrough {
+        // Flythrough mode: automated camera path, no cursor grab, no HUD, no manual input
+        app.add_systems(Startup, setup_scene);
+        app.insert_resource(FlyThroughState::new());
+        app.add_systems(Update, (
+            flythrough_system.run_if(loaded),
+            chunk_stream.run_if(loaded),
+            chunk_poll.run_if(loaded),
+            chunk_unload.run_if(loaded),
+        ));
+    } else {
+        // Normal interactive mode
+        app.add_systems(Startup, (setup_scene, grab_cursor));
+        app.add_systems(Update, (
+            camera_input.run_if(loaded),
+            chunk_stream.run_if(loaded),
+            chunk_poll.run_if(loaded),
+            chunk_unload.run_if(loaded),
+            hud_system.run_if(loaded),
+            exit_on_esc,
+        ));
+    }
 
     app.run();
     Ok(())
@@ -219,6 +236,119 @@ impl Default for FpsCounter {
 
 #[derive(Component)]
 struct ChunkEntity;
+
+// ─── Flythrough ───────────────────────────────────────────────────────────
+
+struct FlyWaypoint {
+    position_offset: Vec3,
+    look_dir: Vec3,
+    duration: f32,
+}
+
+#[derive(Resource)]
+struct FlyThroughState {
+    waypoints: Vec<FlyWaypoint>,
+    current: usize,
+    elapsed: f32,
+    frame_count: u32,
+    output_dir: PathBuf,
+    spawn_pos: Option<Vec3>,
+    screenshot_pending: bool,
+}
+
+impl FlyThroughState {
+    fn new() -> Self {
+        let output_dir = PathBuf::from("/tmp/randlebrot_flythrough");
+        std::fs::create_dir_all(&output_dir).expect("create flythrough output dir");
+        Self {
+            waypoints: vec![
+                // 1. Spawn view — looking forward
+                FlyWaypoint { position_offset: Vec3::ZERO, look_dir: Vec3::new(1.0, 0.0, 0.0), duration: 1.0 },
+                // 2. Turn left 90
+                FlyWaypoint { position_offset: Vec3::ZERO, look_dir: Vec3::new(0.0, 0.0, -1.0), duration: 0.5 },
+                // 3. Turn right 180
+                FlyWaypoint { position_offset: Vec3::ZERO, look_dir: Vec3::new(0.0, 0.0, 1.0), duration: 0.5 },
+                // 4. Look down at feet
+                FlyWaypoint { position_offset: Vec3::ZERO, look_dir: Vec3::new(1.0, -1.0, 0.0).normalize(), duration: 0.5 },
+                // 5. Look up at sky
+                FlyWaypoint { position_offset: Vec3::ZERO, look_dir: Vec3::new(1.0, 1.0, 0.0).normalize(), duration: 0.5 },
+                // 6. Move forward 30 blocks
+                FlyWaypoint { position_offset: Vec3::new(30.0, 0.0, 0.0), look_dir: Vec3::new(1.0, 0.0, 0.0), duration: 2.0 },
+                // 7. Move to high ground (up 20)
+                FlyWaypoint { position_offset: Vec3::new(30.0, 20.0, 0.0), look_dir: Vec3::new(1.0, -0.3, 0.0).normalize(), duration: 1.0 },
+                // 8. Panoramic spin
+                FlyWaypoint { position_offset: Vec3::new(30.0, 20.0, 0.0), look_dir: Vec3::new(-1.0, 0.0, 0.0), duration: 0.5 },
+                // 9. Back at ground
+                FlyWaypoint { position_offset: Vec3::new(30.0, 0.0, 0.0), look_dir: Vec3::new(1.0, 0.0, 0.0), duration: 0.5 },
+                // 10. Final forward view
+                FlyWaypoint { position_offset: Vec3::new(50.0, 0.0, 0.0), look_dir: Vec3::new(1.0, 0.0, 0.0), duration: 1.0 },
+            ],
+            current: 0,
+            elapsed: 0.0,
+            frame_count: 0,
+            output_dir,
+            spawn_pos: None,
+            screenshot_pending: false,
+        }
+    }
+}
+
+fn flythrough_system(
+    mut commands: Commands,
+    mut state: ResMut<FlyThroughState>,
+    time: Res<Time>,
+    mut camera_q: Query<&mut Transform, With<Camera3d>>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    let Ok(mut cam_transform) = camera_q.single_mut() else { return };
+
+    // Record spawn position on first frame
+    if state.spawn_pos.is_none() {
+        state.spawn_pos = Some(cam_transform.translation);
+    }
+    let spawn_pos = state.spawn_pos.unwrap();
+
+    // If a screenshot was just taken, advance to next waypoint
+    if state.screenshot_pending {
+        state.screenshot_pending = false;
+        state.frame_count += 1;
+        state.current += 1;
+        state.elapsed = 0.0;
+
+        if state.current >= state.waypoints.len() {
+            eprintln!(
+                "Flythrough complete: {} frames saved to {:?}",
+                state.frame_count, state.output_dir
+            );
+            exit.write(AppExit::Success);
+            return;
+        }
+    }
+
+    if state.current >= state.waypoints.len() {
+        return;
+    }
+
+    state.elapsed += time.delta_secs();
+    let wp = &state.waypoints[state.current];
+
+    // Interpolate camera position toward current waypoint target
+    let target_pos = spawn_pos + wp.position_offset;
+    let t = (state.elapsed / wp.duration).min(1.0);
+    let smoothed = t * t * (3.0 - 2.0 * t); // smoothstep
+    cam_transform.translation = cam_transform.translation.lerp(target_pos, smoothed.min(1.0));
+    cam_transform.look_to(wp.look_dir, Vec3::Y);
+
+    // When duration is reached, take a screenshot
+    if state.elapsed >= wp.duration && !state.screenshot_pending {
+        state.screenshot_pending = true;
+        let path = state.output_dir.join(format!("frame_{:03}.png", state.frame_count + 1));
+        eprintln!("Capturing frame {} -> {:?}", state.frame_count + 1, path);
+        commands
+            .spawn(Screenshot::primary_window())
+            .observe(save_to_disk(path));
+    }
+}
 
 // ─── Startup ───────────────────────────────────────────────────────────────
 

--- a/src/commands/launch.rs
+++ b/src/commands/launch.rs
@@ -259,6 +259,10 @@ struct FlyThroughState {
 impl FlyThroughState {
     fn new() -> Self {
         let output_dir = PathBuf::from("/tmp/randlebrot_flythrough");
+        // Clean old frames from previous runs
+        if output_dir.exists() {
+            let _ = std::fs::remove_dir_all(&output_dir);
+        }
         std::fs::create_dir_all(&output_dir).expect("create flythrough output dir");
         Self {
             waypoints: vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,9 @@ enum Command {
     Launch {
         /// Tag of the level artifact to launch
         level_tag: String,
+        /// Run an automated flythrough, saving screenshots to /tmp/randlebrot_flythrough/
+        #[arg(long, default_value_t = false)]
+        flythrough: bool,
     },
 
     /// Debug: inspect layer data for a level artifact
@@ -498,8 +501,8 @@ fn main() {
             }
         },
 
-        Some(Command::Launch { level_tag }) => {
-            if let Err(e) = commands::launch::run(level_tag) {
+        Some(Command::Launch { level_tag, flythrough }) => {
+            if let Err(e) = commands::launch::run(level_tag, flythrough) {
                 eprintln!("error: {e}");
                 std::process::exit(1);
             }


### PR DESCRIPTION
## Summary

- Add `--flythrough` bool flag to the `Launch` CLI command in `src/main.rs`
- Implement `FlyThroughState` resource with 10 waypoints covering spawn view, rotations, movement, elevation changes, and panoramic views
- Add `flythrough_system` that advances the camera through waypoints, captures screenshots via Bevy's `Screenshot` API, and auto-exits on completion
- Skip macOS `.app` bundle trampoline when `--flythrough` is set (no keyboard focus needed)
- In flythrough mode, skip `camera_input`, `grab_cursor`, and `hud_system` -- only chunk streaming runs alongside the flythrough
- Screenshots saved to `/tmp/randlebrot_flythrough/frame_NNN.png` (10 frames, ~8 seconds total)
- Update CLAUDE.md: document `--flythrough` in Build & Run section, add verification requirement for visual launcher changes

Closes #42.

## Test plan

- [ ] `cargo check --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace` passes
- [ ] `cargo run --release -- launch <level-tag> --flythrough` runs automated flythrough, saves 10 frames to `/tmp/randlebrot_flythrough/`, and exits
- [ ] `cargo run --release -- launch <level-tag>` still works normally (interactive mode unchanged)
- [ ] On macOS, `--flythrough` skips the `.app` bundle trampoline

🤖 Generated with [Claude Code](https://claude.com/claude-code)